### PR TITLE
Remove flex from some stories for benchmarking

### DIFF
--- a/stories/comparisons/comparisons.stories.tsx
+++ b/stories/comparisons/comparisons.stories.tsx
@@ -138,12 +138,20 @@ const Frame = ({
           overflow: "hidden",
         }}
       >
-        <VirtuaList handle={leftRef} count={count} Component={ItemComponent} />
-        <ComparedList
-          handle={rightRef}
-          count={count}
-          Component={ItemComponent}
-        />
+        <div style={{ width: "50%" }}>
+          <VirtuaList
+            handle={leftRef}
+            count={count}
+            Component={ItemComponent}
+          />
+        </div>
+        <div style={{ width: "50%" }}>
+          <ComparedList
+            handle={rightRef}
+            count={count}
+            Component={ItemComponent}
+          />
+        </div>
       </div>
     </div>
   );

--- a/stories/comparisons/components/react-cool-virtual.tsx
+++ b/stories/comparisons/components/react-cool-virtual.tsx
@@ -20,7 +20,10 @@ export const ReactCoolVirtualList = memo(
     }));
 
     return (
-      <div ref={outerRef} style={{ flex: 1, overflow: "auto" }}>
+      <div
+        ref={outerRef}
+        style={{ width: "100%", height: "100%", overflow: "auto" }}
+      >
         <div ref={innerRef}>
           {items.map(({ index, measureRef }) => (
             <Component key={index} index={index} ref={measureRef} />

--- a/stories/comparisons/components/react-virtual.tsx
+++ b/stories/comparisons/components/react-virtual.tsx
@@ -22,7 +22,10 @@ export const ReactVirtualList = memo(
     }));
 
     return (
-      <div ref={parentRef} style={{ flex: 1, overflow: "auto" }}>
+      <div
+        ref={parentRef}
+        style={{ width: "100%", height: "100%", overflow: "auto" }}
+      >
         <div
           style={{
             height: `${rowVirtualizer.totalSize}px`,

--- a/stories/comparisons/components/react-virtualized.tsx
+++ b/stories/comparisons/components/react-virtualized.tsx
@@ -33,35 +33,33 @@ export const ReactVirtualizedList = memo(
     }));
 
     return (
-      <div style={{ flex: 1 }}>
-        <AutoSizer>
-          {({ width, height }) => (
-            <List
-              ref={ref}
-              deferredMeasurementCache={virtualizedCache}
-              width={width}
-              height={height}
-              rowCount={count}
-              rowHeight={virtualizedCache.rowHeight}
-              rowRenderer={({ index: i, key, style, parent }) => (
-                <CellMeasurer
-                  key={key}
-                  cache={virtualizedCache}
-                  columnIndex={0}
-                  rowIndex={i}
-                  parent={parent}
-                >
-                  {({ registerChild }) => (
-                    <div ref={registerChild} style={style}>
-                      <Component index={i} />
-                    </div>
-                  )}
-                </CellMeasurer>
-              )}
-            />
-          )}
-        </AutoSizer>
-      </div>
+      <AutoSizer>
+        {({ width, height }) => (
+          <List
+            ref={ref}
+            deferredMeasurementCache={virtualizedCache}
+            width={width}
+            height={height}
+            rowCount={count}
+            rowHeight={virtualizedCache.rowHeight}
+            rowRenderer={({ index: i, key, style, parent }) => (
+              <CellMeasurer
+                key={key}
+                cache={virtualizedCache}
+                columnIndex={0}
+                rowIndex={i}
+                parent={parent}
+              >
+                {({ registerChild }) => (
+                  <div ref={registerChild} style={style}>
+                    <Component index={i} />
+                  </div>
+                )}
+              </CellMeasurer>
+            )}
+          />
+        )}
+      </AutoSizer>
     );
   }
 );

--- a/stories/comparisons/components/react-virtuoso.tsx
+++ b/stories/comparisons/components/react-virtuoso.tsx
@@ -2,8 +2,6 @@ import React, { Ref, memo, useImperativeHandle, useMemo, useRef } from "react";
 import { ListHandle, TestComponent } from "./common";
 import { Virtuoso, VirtuosoHandle } from "react-virtuoso";
 
-const listStyle = { flex: 1 };
-
 export const ReactVirtuosoList = memo(
   ({
     count,
@@ -24,7 +22,6 @@ export const ReactVirtuosoList = memo(
     return (
       <Virtuoso
         ref={ref}
-        style={listStyle}
         totalCount={count}
         itemContent={useMemo(() => (i) => <Component key={i} index={i} />, [])}
       />

--- a/stories/comparisons/components/react-window.tsx
+++ b/stories/comparisons/components/react-window.tsx
@@ -55,29 +55,23 @@ export const ReactWindowList = memo(
     }));
 
     return (
-      <div style={{ flex: 1 }}>
-        <AutoSizer>
-          {({ width, height }) => (
-            <RWList
-              ref={ref}
-              width={width}
-              height={height}
-              itemCount={count}
-              itemSize={getHeight}
-            >
-              {({ index: i, style }) => (
-                <div style={style} key={i}>
-                  <RWRow
-                    index={i}
-                    setHeight={setHeight}
-                    Component={Component}
-                  />
-                </div>
-              )}
-            </RWList>
-          )}
-        </AutoSizer>
-      </div>
+      <AutoSizer>
+        {({ width, height }) => (
+          <RWList
+            ref={ref}
+            width={width}
+            height={height}
+            itemCount={count}
+            itemSize={getHeight}
+          >
+            {({ index: i, style }) => (
+              <div style={style} key={i}>
+                <RWRow index={i} setHeight={setHeight} Component={Component} />
+              </div>
+            )}
+          </RWList>
+        )}
+      </AutoSizer>
     );
   }
 );

--- a/stories/comparisons/components/virtua.tsx
+++ b/stories/comparisons/components/virtua.tsx
@@ -2,8 +2,6 @@ import React, { Ref, memo, useImperativeHandle, useRef } from "react";
 import { List, ListHandle as VListHandle } from "virtua";
 import { ListHandle, TestComponent } from "./common";
 
-const listStyle = { flex: 1 };
-
 export const VirtuaList = memo(
   ({
     count,
@@ -22,7 +20,7 @@ export const VirtuaList = memo(
     }));
 
     return (
-      <List ref={ref} style={listStyle}>
+      <List ref={ref}>
         {Array.from({ length: count }).map((_, i) => (
           <Component key={i} index={i} />
         ))}

--- a/stories/comparisons/for benchmarks/react-cool-virtual.stories.tsx
+++ b/stories/comparisons/for benchmarks/react-cool-virtual.stories.tsx
@@ -12,7 +12,7 @@ export default {
   component: ReactCoolVirtualList,
   decorators: [
     (Story) => (
-      <div style={{ height: "100vh", display: "flex" }}>
+      <div style={{ height: "100vh" }}>
         <Story />
       </div>
     ),

--- a/stories/comparisons/for benchmarks/react-virtual.stories.tsx
+++ b/stories/comparisons/for benchmarks/react-virtual.stories.tsx
@@ -12,7 +12,7 @@ export default {
   component: ReactVirtualList,
   decorators: [
     (Story) => (
-      <div style={{ height: "100vh", display: "flex" }}>
+      <div style={{ height: "100vh" }}>
         <Story />
       </div>
     ),

--- a/stories/comparisons/for benchmarks/react-virtualized.stories.tsx
+++ b/stories/comparisons/for benchmarks/react-virtualized.stories.tsx
@@ -12,7 +12,7 @@ export default {
   component: ReactVirtualizedList,
   decorators: [
     (Story) => (
-      <div style={{ height: "100vh", display: "flex" }}>
+      <div style={{ height: "100vh" }}>
         <Story />
       </div>
     ),

--- a/stories/comparisons/for benchmarks/react-virtuoso.stories.tsx
+++ b/stories/comparisons/for benchmarks/react-virtuoso.stories.tsx
@@ -12,7 +12,7 @@ export default {
   component: ReactVirtuosoList,
   decorators: [
     (Story) => (
-      <div style={{ height: "100vh", display: "flex" }}>
+      <div style={{ height: "100vh" }}>
         <Story />
       </div>
     ),

--- a/stories/comparisons/for benchmarks/react-window.stories.tsx
+++ b/stories/comparisons/for benchmarks/react-window.stories.tsx
@@ -12,7 +12,7 @@ export default {
   component: ReactWindowList,
   decorators: [
     (Story) => (
-      <div style={{ height: "100vh", display: "flex" }}>
+      <div style={{ height: "100vh" }}>
         <Story />
       </div>
     ),

--- a/stories/comparisons/for benchmarks/virtua.stories.tsx
+++ b/stories/comparisons/for benchmarks/virtua.stories.tsx
@@ -12,7 +12,7 @@ export default {
   component: VirtuaList,
   decorators: [
     (Story) => (
-      <div style={{ height: "100vh", display: "flex" }}>
+      <div style={{ height: "100vh" }}>
         <Story />
       </div>
     ),


### PR DESCRIPTION
#65 

Some optimization for layout recalculation done in virtua and react-virtualized seems to be disabled with `display: flex`.
So I fixed some style to enable them for now.