### PR TITLE
Remove rerender when cache length is updated

### DIFF
--- a/src/react/VList.spec.tsx
+++ b/src/react/VList.spec.tsx
@@ -226,7 +226,7 @@ describe("render count", () => {
       </Mounter>
     );
 
-    expect(rootFn).toBeCalledTimes(3);
+    expect(rootFn).toBeCalledTimes(2);
     itemFns.forEach((itemFn, i) => {
       expect(itemFn).toBeCalledTimes(i === itemFns.length - 1 ? 0 : 1);
     });
@@ -281,9 +281,9 @@ describe("render count", () => {
       </Mounter>
     );
 
-    expect(rootFn).toBeCalledTimes(4);
+    expect(rootFn).toBeCalledTimes(3);
     itemFns.forEach((itemFn) => {
-      expect(itemFn.mock.calls.length).toBeLessThanOrEqual(2);
+      expect(itemFn.mock.calls.length).toBeLessThanOrEqual(2); // TODO: should be 1
     });
   });
 });

--- a/src/react/VList.tsx
+++ b/src/react/VList.tsx
@@ -13,11 +13,7 @@ import {
   useState,
   ReactFragment,
 } from "react";
-import {
-  ACTION_UPDATE_CACHE_LENGTH,
-  VirtualStore,
-  createVirtualStore,
-} from "../core/store";
+import { VirtualStore, createVirtualStore } from "../core/store";
 import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect";
 import { useSyncExternalStore } from "./useSyncExternalStore";
 import { exists, max, min } from "../core/utils";
@@ -322,17 +318,15 @@ export const VList = forwardRef<VListHandle, VListProps>(
       });
       return arr;
     }, [children]);
-    const elementsCount = elements.length;
+    const count = elements.length;
 
     // https://github.com/facebook/react/issues/25191#issuecomment-1237456448
     const store = useStatic(() =>
-      createVirtualStore(
-        elementsCount,
-        itemSizeProp,
-        !!horizontalProp,
-        !!rtlProp
-      )
+      createVirtualStore(count, itemSizeProp, !!horizontalProp, !!rtlProp)
     );
+    // The elements length and cached items length are different just after element is added/removed.
+    store._updateCacheLength(count);
+
     const [startIndex, endIndex] = useSyncExternalStore(
       store._subscribe,
       store._getRange
@@ -360,14 +354,6 @@ export const VList = forwardRef<VListHandle, VListProps>(
         }
       )
     );
-
-    // The elements length and cached items length are different just after element is added/removed.
-    const count = min(elementsCount, store._getItemCount());
-
-    // So update cache length. Updating state in render will cause warn so use useEffect for now.
-    useIsomorphicLayoutEffect(() => {
-      store._update(ACTION_UPDATE_CACHE_LENGTH, elementsCount);
-    }, [elementsCount]);
 
     useIsomorphicLayoutEffect(() => scroller._initRoot(rootRef[refKey]!), []);
 


### PR DESCRIPTION
When children's length was changed, currently virtua renders twice but this behavior confused animation libraries like framer motion.
This PR will remove the rerender. 

NOTE:
Updating state in render is ok in React, but it can't be used with useSyncExternalStore because it causes `Warining: Cannot update a component (VList) while rendering a different component (VList).`...
It might be a simlar issue to https://github.com/urql-graphql/urql/issues/1382 .