### PR TITLE
Add decreasing storybook example

### DIFF
--- a/stories/basics/VList.stories.tsx
+++ b/stories/basics/VList.stories.tsx
@@ -495,14 +495,23 @@ export const IncreasingItems: StoryObj = {
     };
 
     const [prepend, setPrepend] = useState(false);
+    const [increase, setIncrease] = useState(true);
     const [rows, setRows] = useState(() => createRows(BATCH_LENGTH, 0));
     useEffect(() => {
       const timer = setInterval(() => {
-        setRows((prev) =>
-          prepend
-            ? [...createRows(BATCH_LENGTH, prev[0] - BATCH_LENGTH), ...prev]
-            : [...prev, ...createRows(BATCH_LENGTH, prev[prev.length - 1]! + 1)]
-        );
+        if (increase) {
+          setRows((prev) =>
+            prepend
+              ? [...createRows(BATCH_LENGTH, prev[0] - BATCH_LENGTH), ...prev]
+              : [...prev, ...createRows(BATCH_LENGTH, prev[prev.length - 1]! + 1)]
+          );
+        } else {
+          if (prepend) {
+            setRows((prev) => (prev.slice(BATCH_LENGTH)))
+          } else {
+            setRows((prev) => (prev.slice(0, -BATCH_LENGTH)))
+          }
+        }
       }, 500);
       return () => {
         clearInterval(timer);
@@ -537,6 +546,28 @@ export const IncreasingItems: StoryObj = {
               }}
             />
             prepend
+          </label>
+          <label style={{ marginRight: 4 }}>
+            <input
+              type="radio"
+              style={{ marginLeft: 4 }}
+              checked={increase}
+              onChange={() => {
+                setIncrease(true);
+              }}
+            />
+            increase
+          </label>
+          <label style={{ marginRight: 4 }}>
+            <input
+              type="radio"
+              style={{ marginLeft: 4 }}
+              checked={!increase}
+              onChange={() => {
+                setIncrease(false);
+              }}
+            />
+            decrease
           </label>
         </div>
         <VList style={{ flex: 1 }}>


### PR DESCRIPTION
Hey cool package :)

I've come across a bug; going from `some children` to `no children` then back to `some children` throws a React `Too many re-renders` on the `VList` component

To demonstrate I added the option of "decrease" to the `IncreasingItems` storybook example, so you can easily reproduce. But I haven't got time to delve much deeper

An easy workaround for anyone else encountering this is to skip rendering the `VList` when you know your children array is empty