### PR TITLE
Fix glitch caused by second touch while momentum scrolling in iOS Safari

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -3,7 +3,7 @@
     "name": "Total",
     "path": "lib/index.mjs",
     "import": "*",
-    "limit": "5.3 kB"
+    "limit": "5.35 kB"
   },
   {
     "name": "VList",


### PR DESCRIPTION
fix #211 

https://github.com/prud/ios-overflow-scroll-to-top
https://jsfiddle.net/prud/umr0qegs/
