### PR TITLE
Improve smoothness of smooth scrolling

### DIFF
--- a/e2e/VList.spec.ts
+++ b/e2e/VList.spec.ts
@@ -480,7 +480,7 @@ test.describe("check if scrollToIndex works", () => {
       await expect(await component.innerText()).not.toContain("949");
     });
 
-    test("mid smooth", async ({ page }) => {
+    test("mid smooth", async ({ page, browserName }) => {
       const component = await page.waitForSelector(scrollableSelector);
       await component.waitForElementState("stable");
 
@@ -497,11 +497,7 @@ test.describe("check if scrollToIndex works", () => {
         button
       );
 
-      await clearInput(input);
-      await input.fill("700");
-      await button.click();
-
-      const called = await component.evaluate((c) => {
+      const scrollListener = component.evaluate((c) => {
         let timer: null | NodeJS.Timeout = null;
         let called = 0;
 
@@ -514,14 +510,24 @@ test.describe("check if scrollToIndex works", () => {
             timer = setTimeout(() => {
               c.removeEventListener("scroll", cb);
               resolve(called);
-            }, 200);
+            }, 2000);
           };
           c.addEventListener("scroll", cb);
         });
       });
 
+      await clearInput(input);
+      await input.fill("700");
+      await button.click();
+
+      await page.waitForTimeout(500);
+
+      const called = await scrollListener;
+
       // Check if this is smooth scrolling
-      await expect(called).toBeGreaterThanOrEqual(5);
+      await expect(called).toBeGreaterThanOrEqual(
+        browserName === "webkit" ? 4 : 10
+      );
 
       // Check if scrolled precisely
       const firstItem = await getFirstItem(component);
@@ -638,7 +644,7 @@ test.describe("check if scrollToIndex works", () => {
       await expect(await component.innerText()).not.toContain("949");
     });
 
-    test("mid smooth", async ({ page }) => {
+    test("mid smooth", async ({ page, browserName }) => {
       const component = await page.waitForSelector(scrollableSelector);
       await component.waitForElementState("stable");
 
@@ -655,11 +661,7 @@ test.describe("check if scrollToIndex works", () => {
         button
       );
 
-      await clearInput(input);
-      await input.fill("700");
-      await button.click();
-
-      const called = await component.evaluate((c) => {
+      const scrollListener = component.evaluate((c) => {
         let timer: null | NodeJS.Timeout = null;
         let called = 0;
 
@@ -672,14 +674,24 @@ test.describe("check if scrollToIndex works", () => {
             timer = setTimeout(() => {
               c.removeEventListener("scroll", cb);
               resolve(called);
-            }, 200);
+            }, 2000);
           };
           c.addEventListener("scroll", cb);
         });
       });
 
+      await clearInput(input);
+      await input.fill("700");
+      await button.click();
+
+      await page.waitForTimeout(500);
+
+      const called = await scrollListener;
+
       // Check if this is smooth scrolling
-      await expect(called).toBeGreaterThanOrEqual(5);
+      await expect(called).toBeGreaterThanOrEqual(
+        browserName === "webkit" ? 4 : 10
+      );
 
       // Check if scrolled precisely
       const lastItem = await getLastItem(component);

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -16,7 +16,7 @@ export const getFirstItem = (
 ) => {
   return scrollable.evaluate((s) => {
     const rect = s.getBoundingClientRect();
-    const el = document.elementFromPoint(rect.left + 1, rect.top + 1)!;
+    const el = document.elementFromPoint(rect.left + 2, rect.top + 2)!;
     const elRect = el.getBoundingClientRect();
     return {
       text: el.textContent!,
@@ -31,7 +31,7 @@ export const getLastItem = (
 ) => {
   return scrollable.evaluate((s) => {
     const rect = s.getBoundingClientRect();
-    const el = document.elementFromPoint(rect.left + 1, rect.bottom - 1)!;
+    const el = document.elementFromPoint(rect.left + 2, rect.bottom - 2)!;
     return {
       text: el.textContent!,
       bottom: el.getBoundingClientRect().bottom - rect.bottom,
@@ -43,7 +43,7 @@ export const getFirstItemRtl = (
 ) => {
   return scrollable.evaluate((s) => {
     const rect = s.getBoundingClientRect();
-    const el = document.elementFromPoint(rect.right - 1, rect.top + 1)!;
+    const el = document.elementFromPoint(rect.right - 2, rect.top + 2)!;
     return {
       text: el.textContent!,
       top: el.getBoundingClientRect().top - rect.top,


### PR DESCRIPTION
fix #14 
fix #221 

This PR will change smooth scrolling algorithm to mount all items between start and end for measuring before scrolling.

It may sound that it affects performance, but it will not have much difference because almost all items between start and end will be mounted during smooth scrolling even if we didn't do it manually.