### PR TITLE
Rename VGrid to experimental_VGrid

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -6,15 +6,15 @@
     "limit": "5.5 kB"
   },
   {
-    "name": "VList",
+    "name": "VGrid",
     "path": "lib/index.mjs",
-    "import": "{ VList }",
+    "import": "{ experimental_VGrid }",
     "limit": "4 kB"
   },
   {
-    "name": "VGrid",
+    "name": "VList",
     "path": "lib/index.mjs",
-    "import": "{ VGrid }",
+    "import": "{ VList }",
     "limit": "4 kB"
   },
   {

--- a/.storybook/preview.jsx
+++ b/.storybook/preview.jsx
@@ -10,7 +10,7 @@ export const parameters = {
     storySort: {
       order: [
         "basics",
-        ["VList", "VGrid", "WVList"],
+        ["VList", "WVList", "VGrid"],
         "advanced",
         "comparisons",
       ],

--- a/README.md
+++ b/README.md
@@ -88,30 +88,6 @@ export const App = () => {
 };
 ```
 
-### Vertical and horizontal scroll
-
-```tsx
-import { VGrid } from "virtua";
-
-export const App = () => {
-  return (
-    <VGrid style={{ height: 800 }} row={1000} col={500}>
-      {({ rowIndex, colIndex }) => (
-        <div
-          style={{
-            width: ((colIndex % 3) + 1) * 100,
-            border: "solid 1px gray",
-            background: "white",
-          }}
-        >
-          {rowIndex} / {colIndex}
-        </div>
-      )}
-    </VGrid>
-  );
-};
-```
-
 ### Window scroll
 
 ```tsx
@@ -135,6 +111,30 @@ export const App = () => {
         ))}
       </WVList>
     </div>
+  );
+};
+```
+
+### Vertical and horizontal scroll
+
+```tsx
+import { experimental_VGrid as VGrid } from "virtua";
+
+export const App = () => {
+  return (
+    <VGrid style={{ height: 800 }} row={1000} col={500}>
+      {({ rowIndex, colIndex }) => (
+        <div
+          style={{
+            width: ((colIndex % 3) + 1) * 100,
+            border: "solid 1px gray",
+            background: "white",
+          }}
+        >
+          {rowIndex} / {colIndex}
+        </div>
+      )}
+    </VGrid>
   );
 };
 ```
@@ -207,7 +207,7 @@ It may be dispatched by ResizeObserver in this lib [as described in spec](https:
 | Bundle size                                        | [5.0kB gzipped](https://bundlephobia.com/package/virtua) | [16.9kB gzipped](https://bundlephobia.com/package/react-virtuoso)                                | [6.4kB gzipped](https://bundlephobia.com/package/react-window)                                     | [27.3kB gzipped](https://bundlephobia.com/package/react-virtualized)                                                                                                   | [2.3kB gzipped](https://bundlephobia.com/package/@tanstack/react-virtual) | [3.7kB gzipped](https://bundlephobia.com/package/react-tiny-virtual-list)       | [3.1kB gzipped](https://bundlephobia.com/package/react-cool-virtual)  |
 | Vertical scroll                                    | ✅                                                       | ✅                                                                                               | ✅                                                                                                 | ✅                                                                                                                                                                     | 🟠 (needs customization)                                                  | ✅                                                                              | 🟠 (needs customization)                                              |
 | Horizontal scroll                                  | ✅                                                       | ❌                                                                                               | ✅ ([may be dropped in v2](https://github.com/bvaughn/react-window/issues/302))                    | ✅                                                                                                                                                                     | 🟠 (needs customization)                                                  | ✅                                                                              | 🟠 (needs customization)                                              |
-| Grid (Virtualization for two dimension)            | ✅ (VGrid)                                               | ❌                                                                                               | ✅ (FixedSizeGrid / VariableSizeGrid)                                                              | ✅ ([Grid](https://github.com/bvaughn/react-virtualized/blob/master/docs/Grid.md))                                                                                     | 🟠 (needs customization)                                                  | ❌                                                                              | 🟠 (needs customization)                                              |
+| Grid (Virtualization for two dimension)            | 🟠 (experimental_VGrid)                                  | ❌                                                                                               | ✅ (FixedSizeGrid / VariableSizeGrid)                                                              | ✅ ([Grid](https://github.com/bvaughn/react-virtualized/blob/master/docs/Grid.md))                                                                                     | 🟠 (needs customization)                                                  | ❌                                                                              | 🟠 (needs customization)                                              |
 | Table                                              | 🟠 (needs customization)                                 | ✅ (TableVirtuoso)                                                                               | 🟠 (needs customization)                                                                           | ✅ ([Table](https://github.com/bvaughn/react-virtualized/blob/master/docs/Table.md))                                                                                   | 🟠 (needs customization)                                                  | ❌                                                                              | 🟠 (needs customization)                                              |
 | Window scroller                                    | ✅ (WVList)                                              | ✅                                                                                               | ❌                                                                                                 | ✅ ([WindowScroller](https://github.com/bvaughn/react-virtualized/blob/master/docs/WindowScroller.md))                                                                 | ✅                                                                        | ❌                                                                              | ❌                                                                    |
 | Dynamic list size                                  | ✅                                                       | ✅                                                                                               | 🟠 (needs [AutoSizer](https://github.com/bvaughn/react-virtualized/blob/master/docs/AutoSizer.md)) | 🟠 (needs [AutoSizer](https://github.com/bvaughn/react-virtualized/blob/master/docs/AutoSizer.md))                                                                     | ✅                                                                        | ❌                                                                              | ✅                                                                    |

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,14 +1,14 @@
 export { VList } from "./VList";
 export type { VListProps, VListHandle } from "./VList";
-export { VGrid } from "./VGrid";
+export { WVList } from "./WVList";
+export type { WVListProps, WVListHandle } from "./WVList";
+export { VGrid as experimental_VGrid } from "./VGrid";
 export type {
   VGridProps,
   VGridHandle,
   CustomCellComponent,
   CustomCellComponentProps,
 } from "./VGrid";
-export { WVList } from "./WVList";
-export type { WVListProps, WVListHandle } from "./WVList";
 export type {
   ViewportComponentAttributes,
   CustomViewportComponent,

--- a/stories/basics/VGrid.stories.tsx
+++ b/stories/basics/VGrid.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react";
 import React, { useRef, useState } from "react";
-import { VGrid, VGridHandle } from "../../src";
+import { experimental_VGrid as VGrid, VGridHandle } from "../../src";
 
 export default {
   component: VGrid,


### PR DESCRIPTION
#124 

List virtualization is stable enough and battle tested, but grid virtualization is not yet.
And I've noticed grid virtualization has different usecases from list, like spread sheet or masonry grid. I want to change VGrid drastically to support them.
So rename it for clarification.