### PR TITLE
fix: WVList scroll restoration bug and add storybook example.

### DIFF
--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -110,6 +110,7 @@ export const createVirtualStore = (
   let _smoothScrollRange: ItemsRange | null = null;
   let _maybeJumped = false;
   let _prevRange: ItemsRange = [0, initialItemCount];
+  let _initialRendered = true;
 
   const subscribers = new Set<[number, Subscriber]>();
   const getScrollSize = (): number =>
@@ -223,9 +224,13 @@ export const createVirtualStore = (
             ([index, size]) => cache._sizes[index] !== size
           );
           // Skip if all items are cached and not updated
-          if (!updated.length) {
+          if (
+            !updated.length &&
+            !_initialRendered
+            ) {
             break;
           }
+          _initialRendered = false;
 
           // Calculate jump
           // Should maintain visible position to minimize junks in appearance

--- a/src/react/WVList.tsx
+++ b/src/react/WVList.tsx
@@ -201,7 +201,7 @@ export const WVList = forwardRef<WVListHandle, WVListProps>(
       return () => {
         cleanupResizer();
         cleanupScroller();
-        unsubscribeStore;
+        unsubscribeStore();
       };
     }, []);
 


### PR DESCRIPTION
**Bug**
Items aren't displayed properly when all of the following conditions are met.
- passing cache props to WVList and exists cache.
-  both the current page scrollY and the previous page scrollY are 0, and the scroll action registered in eventListener does not be called.

**To Reproduce**
[demo on stackblitz.com](https://stackblitz.com/edit/virtua-scroll-restoration-nhynzv?file=package.json,src%2Fmain.tsx,src%2FApp.tsx&terminal=dev)
1. Check Passing cache props to WVList.
2. Move from the document which isn't scrolled at all up or down (scrollY is 0) to the WVList document which isn't too (scrollY is 0). 
3. WVList displayed only a few items.

<img src="https://github.com/inokawa/virtua/assets/85535158/6ecd2e01-6887-42f9-91cf-c054257cc6f4" width="400">

**Platform:**
- OS: Windows
- Browser: Chrome
- Version of react: 18.2.0
- Version of this package: 0.15.7

**Bug fix**
I don't know what is the real problem, but re-render solve the issue. Specifically, bypassing cache condition when executing an action for `ACTION_ITEM_RESIZE` on initial render, and it cause re-render.
https://github.com/caprolactam/virtua/blob/ddf74a0dab0e217a15448410382ac150ee0125d7/src/core/store.ts#L222-L232
However, VList scroll restoration works properly without this workaround🤔.

**Tests Plan**

**Suggestion**
I think there is room for improvement about storybook exmaple. The details are as follows.
When managing scroll position manually, you need previous scroll position to use window.scrollTo(). In this case, it could be more appropriate to get the offset by exposing the `scrollOffset` using WVListHandle instead of using `window.scrollY` (or scrollX). In the case of storybook, when you hide WVList, `window.scrollY` will return 0 in useEffect cleanup, but `scrollOffset` allows you to retrieve the scroll offset stored in VirtualStore. The former behavior is not necessarily incorrect, but users might prefer to be restored to the position provided by the latter.
