### PR TITLE
Fix CacheSnapshot structure and reduce its size

### DIFF
--- a/src/core/cache.spec.ts
+++ b/src/core/cache.spec.ts
@@ -10,6 +10,7 @@ import {
   initCache,
   computeRange,
   estimateDefaultItemSize,
+  takeCacheSnapshot,
 } from "./cache";
 
 const range = <T>(length: number, cb: (i: number) => T): T[] => {
@@ -779,6 +780,75 @@ describe(initCache.name, () => {
         ],
       }
     `);
+  });
+
+  it("should create cache from snapshot", () => {
+    expect(initCache(10, 23, [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], 123]))
+      .toMatchInlineSnapshot(`
+      {
+        "_computedOffsetIndex": -1,
+        "_defaultItemSize": 123,
+        "_length": 10,
+        "_offsets": [
+          -1,
+          -1,
+          -1,
+          -1,
+          -1,
+          -1,
+          -1,
+          -1,
+          -1,
+          -1,
+        ],
+        "_sizes": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+        ],
+      }
+    `);
+  });
+});
+
+describe(takeCacheSnapshot.name, () => {
+  it("smoke", () => {
+    const cache = initCacheWithComputedOffsets(
+      range(10, (i) => (i + 1) * 10),
+      40
+    );
+    const snapshot = takeCacheSnapshot(cache);
+    expect(snapshot).toMatchInlineSnapshot(`
+      [
+        [
+          10,
+          20,
+          30,
+          40,
+          50,
+          60,
+          70,
+          80,
+          90,
+          100,
+        ],
+        40,
+      ]
+    `);
+
+    // Check if modifying snapshot doesn't affect cache
+    const clonedSnapshot = structuredClone(snapshot);
+    snapshot[0][0] = 999;
+    snapshot[1] = 123;
+    expect(snapshot).not.toEqual(clonedSnapshot);
+    expect(takeCacheSnapshot(cache)).toEqual(clonedSnapshot);
   });
 });
 

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -1,4 +1,4 @@
-import { ItemsRange } from "./types";
+import { InternalCacheSnapshot, ItemsRange } from "./types";
 import { clamp, max, median, min } from "./utils";
 
 type Writeable<T> = {
@@ -160,14 +160,25 @@ export const estimateDefaultItemSize = (
 /**
  * @internal
  */
-export const initCache = (length: number, itemSize: number): Cache => {
+export const initCache = (
+  length: number,
+  itemSize: number,
+  snapshot?: InternalCacheSnapshot
+): Cache => {
   return {
-    _defaultItemSize: itemSize,
+    _defaultItemSize: snapshot ? snapshot[1] : itemSize,
+    _sizes: snapshot ? snapshot[0] : fill([], length),
     _length: length,
     _computedOffsetIndex: -1,
-    _sizes: fill([], length),
     _offsets: fill([], length),
   };
+};
+
+/**
+ * @internal
+ */
+export const takeCacheSnapshot = (cache: Cache): InternalCacheSnapshot => {
+  return [[...cache._sizes], cache._defaultItemSize];
 };
 
 /**

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3,6 +3,9 @@ export type ItemResize = Readonly<[index: number, size: number]>;
 /** @internal */
 export type ItemsRange = Readonly<[startIndex: number, endIndex: number]>;
 
+/** @internal */
+export type InternalCacheSnapshot = [sizes: number[], defaultSize: number];
+
 declare const cacheSymbol: unique symbol;
 /**
  * Serializable cache snapshot.


### PR DESCRIPTION
Removed some fields from snapshot because they are restorable from item sizes.

- [ ] is it better including scrollOffset in snapshot?