### PR TITLE
Fix solid reactivity

### DIFF
--- a/src/solid/RangedFor.tsx
+++ b/src/solid/RangedFor.tsx
@@ -9,6 +9,7 @@ import {
   untrack,
   JSX,
   Signal,
+  Accessor,
 } from "solid-js";
 import { ItemsRange } from "../core/types";
 
@@ -27,7 +28,7 @@ interface RenderedNode<T> {
 export const RangedFor = <T,>(props: {
   _each: T[];
   _range: ItemsRange;
-  _render: (data: T, index: number) => JSX.Element;
+  _render: (data: Accessor<T>, index: number) => JSX.Element;
 }): JSX.Element => {
   let prev = new Map<number, RenderedNode<T>>();
 
@@ -52,7 +53,7 @@ export const RangedFor = <T,>(props: {
             ? lookup._element
             : createRoot((dispose) => {
                 const data = createSignal(newData);
-                const result = props._render(data[0](), i);
+                const result = props._render(data[0], i);
                 current.set(i, {
                   _data: data,
                   _element: result,

--- a/src/solid/Virtualizer.tsx
+++ b/src/solid/Virtualizer.tsx
@@ -295,7 +295,7 @@ export const Virtualizer = <T,>(props: VirtualizerProps<T>): JSX.Element => {
               _resizer={resizer._observeItem}
               _offset={offset()}
               _hide={hide()}
-              _children={props.children(data, index)}
+              _children={props.children(data(), index)}
               _isHorizontal={horizontal}
             />
           );

--- a/src/solid/WindowVirtualizer.tsx
+++ b/src/solid/WindowVirtualizer.tsx
@@ -228,7 +228,7 @@ export const WindowVirtualizer = <T,>(
               _resizer={resizer._observeItem}
               _offset={offset()}
               _hide={hide()}
-              _children={props.children(data, index)}
+              _children={props.children(data(), index)}
               _isHorizontal={horizontal}
             />
           );


### PR DESCRIPTION
fix #425 

The reactivity seems to break inside the `RangedFor` component. 
With this change each item is passed as a function instead of as a value to the render function, which seems to fix the problem, without having to change the api of the library. I sadly don't know enough about solid to find out why passing it as a value is not working. 

To fix the reactivity when using `createStore` instead of `createSignal`, like in the following example: 

```
const App: Component = () => {
  const [data, setData] = createStore(Array.from({ length: 100000 }, (v, i) => i));
  return (
    <>
      <button onClick={() => {
        setData(10, prev => prev * 2)
        }}>
        Update data
      </button>
      <VList data={data} style={{ height: "800px" }}>
        {(item, i) => (
          <div>
            {item}
          </div>
        )}
      </VList>
    </>
  );
}
```

The `untrack()` call inside the `RangedFor` had to be removed. I think that this change can cause some unnecessary rerenders, but i could not notice any worse performance even when rendering lists with 100k+ elements. 

Not sure if this pull request is going to be helpful, since i could not find out the reasons why these changes have to be made, or if there are better alternatives, but i think this could be a good enough solution to the problem until somebody with more experience in solid can fix this. 