### PR TITLE
Add ability to keep offscreen items mounted

### DIFF
--- a/src/react/VList.tsx
+++ b/src/react/VList.tsx
@@ -29,6 +29,7 @@ export interface VListProps
       | "onScroll"
       | "onScrollEnd"
       | "onRangeChange"
+      | "keepMounted"
     >,
     ViewportComponentAttributes {
   /**
@@ -46,6 +47,7 @@ export const VList = forwardRef<VListHandle, VListProps>(
       children,
       count,
       overscan,
+      keepMounted,
       itemSize,
       shift,
       horizontal,
@@ -70,6 +72,7 @@ export const VList = forwardRef<VListHandle, VListProps>(
         scrollRef={shouldReverse ? scrollRef : undefined}
         count={count}
         overscan={overscan}
+        keepMounted={keepMounted}
         itemSize={itemSize}
         shift={shift}
         horizontal={horizontal}

--- a/src/react/Virtualizer.tsx
+++ b/src/react/Virtualizer.tsx
@@ -94,6 +94,10 @@ export interface VirtualizerProps {
    */
   overscan?: number;
   /**
+   * List of indexes that should be always mounted, even when off screen.
+   */
+  keepMounted?: number[];
+  /**
    * Item size hint for unmeasured items. It will help to reduce scroll jump when items are measured if used properly.
    *
    * - If not set, initial item sizes will be automatically estimated from measured sizes. This is recommended for most cases.
@@ -167,6 +171,7 @@ export const Virtualizer = forwardRef<VirtualizerHandle, VirtualizerProps>(
       children,
       count: renderCountProp,
       overscan = 4,
+      keepMounted = [],
       itemSize,
       shift,
       horizontal: horizontalProp,
@@ -303,32 +308,47 @@ export const Virtualizer = forwardRef<VirtualizerHandle, VirtualizerProps>(
       []
     );
 
+    const [overscanedRangeStart, overscanedRangeEnd] = getOverscanedRange(
+      startIndex,
+      endIndex,
+      overscan,
+      scrollDirection,
+      count
+    );
+
+    const getListItem = (index: number) => {
+      const e = getElement(index);
+
+      return <ListItem
+        key={getKey(e, index)}
+        _resizer={resizer._observeItem}
+        _index={index}
+        _offset={store._getItemOffset(index)}
+        _hide={store._isUnmeasuredItem(index)}
+        _element={ItemElement as "div"}
+        _children={e}
+        _isHorizontal={isHorizontal}
+        _isSSR={isSSR[refKey]}
+      />
+    }
+
     for (
-      let [i, j] = getOverscanedRange(
-        startIndex,
-        endIndex,
-        overscan,
-        scrollDirection,
-        count
-      );
+      let [i, j] = [overscanedRangeStart, overscanedRangeEnd];
       i <= j;
       i++
     ) {
-      const e = getElement(i);
-      items.push(
-        <ListItem
-          key={getKey(e, i)}
-          _resizer={resizer._observeItem}
-          _index={i}
-          _offset={store._getItemOffset(i)}
-          _hide={store._isUnmeasuredItem(i)}
-          _element={ItemElement as "div"}
-          _children={e}
-          _isHorizontal={isHorizontal}
-          _isSSR={isSSR[refKey]}
-        />
-      );
+      items.push(getListItem(i));
     }
+
+    keepMounted.forEach(index => {
+      if (index < overscanedRangeStart) {
+        items.unshift(getListItem(index))
+      }
+
+      if (index > overscanedRangeEnd) {
+        items.push(getListItem(index))
+      }
+    })
 
     return (
       <Element

--- a/stories/react/advanced/Keep offscreen items mounted.stories.tsx
+++ b/stories/react/advanced/Keep offscreen items mounted.stories.tsx
@@ -1,0 +1,147 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { VList, VListHandle } from "../../../src";
+import React, {
+  CSSProperties,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { faker } from "@faker-js/faker";
+
+export default {
+  component: VList,
+} as Meta;
+
+type Data = {
+  id: number;
+  value: string;
+};
+
+type ItemProps = Data & {
+  isEditing: boolean;
+  toggleEditing: (id: number) => void;
+}
+
+const itemStyle: CSSProperties = {
+  border: "solid 1px #ccc",
+  background: "#fff",
+  margin: 10,
+  padding: 10,
+  borderRadius: 8,
+  whiteSpace: "pre-wrap",
+};
+
+const TextEditor = ({ value }) => {
+  const ref = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    ref.current?.focus();
+  }, [])
+
+  return <textarea
+    style={{ width: "100%" }}
+    rows={6}
+    ref={ref}
+    defaultValue={value}
+  />
+}
+
+const Item = ({ id, value, isEditing, toggleEditing }: ItemProps) => {
+  return (
+    <div
+      style={{
+        ...itemStyle,
+      }}
+    >
+      {isEditing ? <TextEditor value={value} /> : value}
+      <div>
+        <button onClick={() => toggleEditing(id)}>
+          {isEditing ? "Stop editing" : "Edit"}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export const Default: StoryObj = {
+  name: "Keep offscreen items mounted",
+  render: () => {
+    const id = useRef(0);
+    const createItem = ({
+      value = faker.lorem.paragraphs(1),
+    }: {
+      value?: string;
+    } = {}): Data => ({
+      id: id.current++,
+      value: value,
+    });
+    const [items, setItems] = useState(() =>
+      Array.from({ length: 20 }, () => createItem())
+    );
+    const [editingItemId, setEditingItemId] = useState<number | null>(null);
+
+    const ref = useRef<VListHandle>(null);
+
+    const isPrepend = useRef(false);
+
+    useLayoutEffect(() => {
+      isPrepend.current = false;
+    });
+
+    useEffect(() => {
+      if (!ref.current) return;
+
+      ref.current.scrollToIndex(items.length - 1, { align: "end" });
+    }, []);
+
+    const toggleEditing = useCallback((itemId: number) => {
+      setEditingItemId(currentValue => itemId === currentValue ? null : itemId);
+    }, [])
+
+    return (
+      <div
+        style={{
+          width: "90vw",
+          height: "90vh",
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        <div style={{ padding: 10 }}>
+          1. Click "edit" button on any item<br />
+          2. Modify text<br />
+          3. Scroll that item out of view and back - the editor state is not lost, and 
+          item in edit mode is not unmounted when goes offscreen
+        </div>
+        <VList
+          ref={ref}
+          style={{ flex: 1 }}
+          reverse
+          keepMounted={editingItemId
+            ? [items.findIndex(item => item.id === editingItemId)]
+            : undefined
+          }
+          shift
+          onScroll={(offset) => {
+            if (!ref.current) return;
+
+            if (offset < 100) {
+              isPrepend.current = true;
+              setItems((p) => [
+                ...Array.from({ length: 20 }, () => createItem()),
+                ...p,
+              ]);
+            }
+          }}
+        >
+          {items.map((d) => (
+            <Item key={d.id} isEditing={d.id === editingItemId}
+            toggleEditing={toggleEditing} {...d} />
+          ))}
+        </VList>
+      </div>
+    );
+  },
+};


### PR DESCRIPTION
fix #181 

This simple change fixes a number of issues with off-screen elements:
- audio/video stops playing
- issue with text input focus I mentioned in this discussion https://github.com/inokawa/virtua/discussions/414
- text input loses its state

But I'm guessing you wanted to find a generic solution that covers more use cases, right?

This seems to solve the most critical issues for me. The new prop could be added with `unstable_` or `experimental_` prefix, until you find a better solution, what do you think?