### PR TITLE
Fix off-screen items order

### DIFF
--- a/src/react/Virtualizer.tsx
+++ b/src/react/Virtualizer.tsx
@@ -338,16 +338,21 @@ export const Virtualizer = forwardRef<VirtualizerHandle, VirtualizerProps>(
       items.push(getListItem(i));
     }
 
-    keepMounted &&
-      keepMounted.forEach((index) => {
-        if (index < overscanedRangeStart) {
-          items.unshift(getListItem(index));
-        }
+    const startItems: ReactElement[] = [];
+    const endItems: ReactElement[] = [];
 
+    keepMounted &&
+      keepMounted.sort((a, b) => a - b).forEach((index) => {
+        if (index < overscanedRangeStart) {
+          startItems.push(getListItem(index));
+        }
         if (index > overscanedRangeEnd) {
-          items.push(getListItem(index));
+          endItems.push(getListItem(index));
         }
       });
+
+    items.unshift(...startItems);
+    items.push(...endItems);
 
     return (
       <Element

--- a/src/react/Virtualizer.tsx
+++ b/src/react/Virtualizer.tsx
@@ -338,21 +338,23 @@ export const Virtualizer = forwardRef<VirtualizerHandle, VirtualizerProps>(
       items.push(getListItem(i));
     }
 
-    const startItems: ReactElement[] = [];
-    const endItems: ReactElement[] = [];
+    if (keepMounted) {
+      const startItems: ReactElement[] = [];
+      const endItems: ReactElement[] = [];
+      keepMounted
+        .sort((a, b) => a - b)
+        .forEach((index) => {
+          if (index < overscanedRangeStart) {
+            startItems.push(getListItem(index));
+          }
+          if (index > overscanedRangeEnd) {
+            endItems.push(getListItem(index));
+          }
+        });
 
-    keepMounted &&
-      keepMounted.sort((a, b) => a - b).forEach((index) => {
-        if (index < overscanedRangeStart) {
-          startItems.push(getListItem(index));
-        }
-        if (index > overscanedRangeEnd) {
-          endItems.push(getListItem(index));
-        }
-      });
-
-    items.unshift(...startItems);
-    items.push(...endItems);
+      items.unshift(...startItems);
+      items.push(...endItems);
+    }
 
     return (
       <Element


### PR DESCRIPTION
Turned out that incorrect items order may cause some issues. And it cannot be fixed by sorting indexes on the user side, because `unshift` will break their order anyway.

In my case it was an embedded YouTube video that would autoplay multiple times in some conditions. Seems like the wrong items order caused react to re-create DOM elements.