### PR TITLE
Inject scrollRef into VList

### DIFF
--- a/src/react/VList.tsx
+++ b/src/react/VList.tsx
@@ -30,6 +30,7 @@ export interface VListProps
       | "onScrollEnd"
       | "onRangeChange"
       | "keepMounted"
+      | "scrollRef"
     >,
     ViewportComponentAttributes {
   /**
@@ -59,11 +60,13 @@ export const VList = forwardRef<VListHandle, VListProps>(
       onScrollEnd,
       onRangeChange,
       style,
+      scrollRef: injectedScrollRef,
       ...attrs
     },
     ref
   ): ReactElement => {
-    const scrollRef = useRef<HTMLDivElement>(null);
+    const internalScrollRef = useRef<HTMLDivElement>(null);
+    const scrollRef = injectedScrollRef || internalScrollRef;
     const shouldReverse = reverse && !horizontal;
 
     let element = (

--- a/src/react/Virtualizer.tsx
+++ b/src/react/Virtualizer.tsx
@@ -139,7 +139,7 @@ export interface VirtualizerProps {
   /**
    * Reference to the scrollable element. The default will get the parent element of virtualizer.
    */
-  scrollRef?: RefObject<HTMLElement>;
+  scrollRef?: RefObject<HTMLDivElement>;
   /**
    * Callback invoked whenever scroll offset changes.
    * @param offset Current scrollTop or scrollLeft.


### PR DESCRIPTION
https://github.com/inokawa/virtua/issues/444

Currently, in VLlist, we can obtain the viewport size but there is no method to get the size of the scrollbar. Therefore, I have modified it to allow injecting `scrollRef` to use ResizeObserver to obtain the size of the scrollbar.

screencast

https://github.com/inokawa/virtua/assets/6832636/adf85dc8-c6b7-4968-bca2-373abf8d3d79

