### PR TITLE
Fix infinite resize issue

### DIFF
--- a/src/react/Virtualizer.tsx
+++ b/src/react/Virtualizer.tsx
@@ -371,6 +371,7 @@ export const Virtualizer = forwardRef<VirtualizerHandle, VirtualizerProps>(
           width: isHorizontal ? totalSize : "100%",
           height: isHorizontal ? "100%" : totalSize,
           pointerEvents: scrollDirection !== SCROLL_IDLE ? "none" : "auto",
+          overflowY: 'hidden'
         }}
       >
         {items}


### PR DESCRIPTION
**Issue:** in reversed list with small number of items at some breakpoint infinite resize can happen.
**Precondition**: show scrollbar set to "always" in system setting

**Video**: 
https://github.com/user-attachments/assets/5f7c955a-6b9b-44cd-82ba-e6d8ea07a81a

I couldn't fully understand how it works, but it depends on the styles of the element that wraps the virtual list component. In [Codesandbox](https://codesandbox.io/p/sandbox/virtua-shaking-vwqc2n) you can find 2 examples - where the issue happens and where it doesn't.

Experimentally I found out that setting `overflow-y: hidden` to virtual list items wrapper element fixes the issue. It looks like it's safe to add this style.

**Note**:  I haven't tested horizontal scroll and don't know if it requires different styles