### PR TITLE
add onWheel to VList

### DIFF
--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -2,7 +2,7 @@ import { CSSProperties, ReactNode } from "react";
 
 export type ViewportComponentAttributes = Pick<
   React.HTMLAttributes<HTMLElement>,
-  "className" | "style" | "id" | "role" | "tabIndex" | "onKeyDown"
+  "className" | "style" | "id" | "role" | "tabIndex" | "onKeyDown" | "onWheel"
 > &
   React.AriaAttributes;
 

--- a/src/solid/types.ts
+++ b/src/solid/types.ts
@@ -2,6 +2,6 @@ import { JSX } from "solid-js";
 
 export type ViewportComponentAttributes = Pick<
   JSX.HTMLAttributes<HTMLElement>,
-  "class" | "id" | "role" | "tabIndex" | "onKeyDown"
+  "class" | "id" | "role" | "tabIndex" | "onKeyDown" | "onWheel"
 > &
   JSX.AriaAttributes & { style?: JSX.CSSProperties };


### PR DESCRIPTION
Updates `ViewportComponentAttributes` to expose `onWheel` in `VList`.

Enables user to differentiate automated scroll behaviour from mouse scroll.

Solves problem from [this discussion](https://github.com/inokawa/virtua/discussions/486#discussioncomment-10278043).