### PR TITLE
Add `getItemSize` to `VirtualizerHandle`

### DIFF
--- a/src/react/Virtualizer.tsx
+++ b/src/react/Virtualizer.tsx
@@ -58,6 +58,11 @@ export interface VirtualizerHandle {
    */
   getItemOffset(index: number): number;
   /**
+   * Get item size.
+   * @param index index of item
+   */
+  getItemSize(index: number): number;
+  /**
    * Scroll to the item specified by index.
    * @param index index of item
    * @param opts options
@@ -324,6 +329,7 @@ export const Virtualizer = forwardRef<VirtualizerHandle, VirtualizerProps>(
             return store._getViewportSize();
           },
           getItemOffset: store._getItemOffset,
+          getItemSize: store._getItemSize,
           scrollToIndex: scroller._scrollToIndex,
           scrollTo: scroller._scrollTo,
           scrollBy: scroller._scrollBy,

--- a/src/solid/Virtualizer.tsx
+++ b/src/solid/Virtualizer.tsx
@@ -54,6 +54,11 @@ export interface VirtualizerHandle {
    */
   getItemOffset(index: number): number;
   /**
+   * Get item size.
+   * @param index index of item
+   */
+  getItemSize(index: number): number;
+  /**
    * Scroll to the item specified by index.
    * @param index index of item
    * @param opts options
@@ -223,6 +228,7 @@ export const Virtualizer = <T,>(props: VirtualizerProps<T>): JSX.Element => {
           return store._getViewportSize();
         },
         getItemOffset: store._getItemOffset,
+        getItemSize: store._getItemSize,
         scrollToIndex: scroller._scrollToIndex,
         scrollTo: scroller._scrollTo,
         scrollBy: scroller._scrollBy,

--- a/src/svelte/VList.svelte
+++ b/src/svelte/VList.svelte
@@ -27,6 +27,14 @@
     ref.getScrollSize()) satisfies VListHandle["getScrollSize"] as VListHandle["getScrollSize"];
   export const getViewportSize = (() =>
     ref.getViewportSize()) satisfies VListHandle["getViewportSize"] as VListHandle["getViewportSize"];
+  export const getItemOffset = ((...args) =>
+    ref.getItemOffset(
+      ...args
+    )) satisfies VListHandle["getItemOffset"] as VListHandle["getItemOffset"];
+  export const getItemSize = ((...args) =>
+    ref.getItemSize(
+      ...args
+    )) satisfies VListHandle["getItemSize"] as VListHandle["getItemSize"];
   export const scrollToIndex = ((...args) =>
     ref.scrollToIndex(
       ...args

--- a/src/svelte/Virtualizer.svelte
+++ b/src/svelte/Virtualizer.svelte
@@ -25,6 +25,7 @@
     CHANGE_START_MARGIN,
     GET_START_SPACER_SIZE,
     GET_ITEMS_LENGTH,
+    GET_ITEM_SIZE,
   } from "./core";
   import { defaultGetKey, styleToString } from "./utils";
   import ListItem from "./ListItem.svelte";
@@ -131,6 +132,12 @@
   export const getViewportSize = virtualizer[
     GET_VIEWPORT_SIZE
   ] satisfies VirtualizerHandle["getViewportSize"] as VirtualizerHandle["getViewportSize"];
+  export const getItemOffset = virtualizer[
+    GET_ITEM_OFFSET
+  ] satisfies VirtualizerHandle["getItemOffset"] as VirtualizerHandle["getItemOffset"];
+  export const getItemSize = virtualizer[
+    GET_ITEM_SIZE
+  ] satisfies VirtualizerHandle["getItemSize"] as VirtualizerHandle["getItemSize"];
   export const scrollToIndex = virtualizer[
     SCROLL_TO_INDEX
   ] satisfies VirtualizerHandle["scrollToIndex"] as VirtualizerHandle["scrollToIndex"];

--- a/src/svelte/Virtualizer.type.ts
+++ b/src/svelte/Virtualizer.type.ts
@@ -91,6 +91,16 @@ export interface VirtualizerHandle {
    */
   getViewportSize: () => number;
   /**
+   * Get item offset from start.
+   * @param index index of item
+   */
+  getItemOffset(index: number): number;
+  /**
+   * Get item size.
+   * @param index index of item
+   */
+  getItemSize(index: number): number;
+  /**
    * Scroll to the item specified by index.
    * @param index index of item
    * @param opts options

--- a/src/svelte/core.ts
+++ b/src/svelte/core.ts
@@ -29,17 +29,18 @@ export const GET_SCROLL_OFFSET = 5;
 export const GET_SCROLL_DIRECTION = 6;
 export const GET_JUMP_COUNT = 7;
 export const GET_ITEM_OFFSET = 8;
-export const IS_ITEM_HIDDEN = 9;
-export const GET_ITEMS_LENGTH = 10;
-export const GET_START_SPACER_SIZE = 11;
-export const OBSERVE_ITEM_RESIZE = 12;
-export const FIX_SCROLL_JUMP = 13;
-export const CHANGE_ITEM_LENGTH = 14;
-export const CHANGE_START_MARGIN = 15;
-export const GET_SCROLL_SIZE = 16;
-export const SCROLL_TO = 17;
-export const SCROLL_BY = 18;
-export const SCROLL_TO_INDEX = 19;
+export const GET_ITEM_SIZE = 9;
+export const IS_ITEM_HIDDEN = 10;
+export const GET_ITEMS_LENGTH = 11;
+export const GET_START_SPACER_SIZE = 12;
+export const OBSERVE_ITEM_RESIZE = 13;
+export const FIX_SCROLL_JUMP = 14;
+export const CHANGE_ITEM_LENGTH = 15;
+export const CHANGE_START_MARGIN = 16;
+export const GET_SCROLL_SIZE = 17;
+export const SCROLL_TO = 18;
+export const SCROLL_BY = 19;
+export const SCROLL_TO_INDEX = 20;
 
 /**
  * This function is workaround for terser minification.
@@ -95,6 +96,7 @@ export const createVirtualizer = (
     [GET_SCROLL_DIRECTION]: store._getScrollDirection,
     [GET_JUMP_COUNT]: store._getJumpCount,
     [GET_ITEM_OFFSET]: store._getItemOffset,
+    [GET_ITEM_SIZE]: store._getItemSize,
     [IS_ITEM_HIDDEN]: store._isUnmeasuredItem,
     [GET_ITEMS_LENGTH]: store._getItemsLength,
     [GET_START_SPACER_SIZE]: store._getStartSpacerSize,

--- a/src/vue/VList.tsx
+++ b/src/vue/VList.tsx
@@ -72,6 +72,7 @@ export const VList = /*#__PURE__*/ defineComponent({
         return handle.value!.viewportSize;
       },
       getItemOffset: (...args) => handle.value!.getItemOffset(...args),
+      getItemSize: (...args) => handle.value!.getItemSize(...args),
       scrollToIndex: (...args) => handle.value!.scrollToIndex(...args),
       scrollTo: (...args) => handle.value!.scrollTo(...args),
       scrollBy: (...args) => handle.value!.scrollBy(...args),

--- a/src/vue/Virtualizer.tsx
+++ b/src/vue/Virtualizer.tsx
@@ -50,6 +50,11 @@ export interface VirtualizerHandle {
    */
   getItemOffset(index: number): number;
   /**
+   * Get item size.
+   * @param index index of item
+   */
+  getItemSize(index: number): number;
+  /**
    * Scroll to the item specified by index.
    * @param index index of item
    * @param opts options
@@ -218,6 +223,7 @@ export const Virtualizer = /*#__PURE__*/ defineComponent({
         return store._getViewportSize();
       },
       getItemOffset: store._getItemOffset,
+      getItemSize: store._getItemSize,
       scrollToIndex: scroller._scrollToIndex,
       scrollTo: scroller._scrollTo,
       scrollBy: scroller._scrollBy,


### PR DESCRIPTION
Exposing `getItemSize` to the `VirtualizerHandle`.

This will enable users to create their own `scrollToIndex` behavior as discussed in #538 