### PR TITLE
Replace onRangeChange with handle methods

### DIFF
--- a/src/core/scroller.ts
+++ b/src/core/scroller.ts
@@ -11,7 +11,6 @@ import {
   ACTION_SCROLL_END,
   UPDATE_SIZE_EVENT,
   ACTION_MANUAL_SCROLL,
-  SCROLL_IDLE,
   ACTION_BEFORE_MANUAL_SMOOTH_SCROLL,
   ACTION_START_OFFSET_CHANGE,
   isInitialMeasurementDone,
@@ -90,7 +89,7 @@ const createScrollObserver = (
     if (
       wheeling ||
       // Scroll start should be detected with scroll event
-      store._getScrollDirection() === SCROLL_IDLE ||
+      !store._isScrolling() ||
       // Probably a pinch-to-zoom gesture
       e.ctrlKey
     ) {

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -9,6 +9,7 @@ import {
   updateCacheLength,
   computeRange,
   takeCacheSnapshot,
+  findIndex,
 } from "./cache";
 import { isIOSWebKit } from "./environment";
 import type {
@@ -19,14 +20,10 @@ import type {
 } from "./types";
 import { abs, max, min, NULL } from "./utils";
 
-/** @internal */
-export const SCROLL_IDLE = 0;
-/** @internal */
-export const SCROLL_DOWN = 1;
-/** @internal */
-export const SCROLL_UP = 2;
-/** @internal */
-export type ScrollDirection =
+const SCROLL_IDLE = 0;
+const SCROLL_DOWN = 1;
+const SCROLL_UP = 2;
+type ScrollDirection =
   | typeof SCROLL_IDLE
   | typeof SCROLL_DOWN
   | typeof SCROLL_UP;
@@ -92,25 +89,6 @@ export const isInitialMeasurementDone = (store: VirtualStore): boolean => {
   return !!store._getViewportSize();
 };
 
-/**
- * @internal
- */
-export const getOverscanedRange = (
-  startIndex: number,
-  endIndex: number,
-  overscan: number,
-  scrollDirection: ScrollDirection,
-  count: number
-): ItemsRange => {
-  if (scrollDirection !== SCROLL_DOWN) {
-    startIndex -= max(0, overscan);
-  }
-  if (scrollDirection !== SCROLL_UP) {
-    endIndex += max(0, overscan);
-  }
-  return [max(startIndex, 0), min(endIndex, count - 1)];
-};
-
 type Subscriber = (sync?: boolean) => void;
 
 /** @internal */
@@ -123,13 +101,15 @@ export type VirtualStore = {
   _getStateVersion(): StateVersion;
   _getCacheSnapshot(): CacheSnapshot;
   _getRange(): ItemsRange;
+  _getStartIndex(): number;
+  _getEndIndex(): number;
   _isUnmeasuredItem(index: number): boolean;
   _hasUnmeasuredItemsInFrozenRange(): boolean;
   _getItemOffset(index: number): number;
   _getItemSize(index: number): number;
   _getItemsLength(): number;
   _getScrollOffset(): number;
-  _getScrollDirection(): ScrollDirection;
+  _isScrolling(): boolean;
   _getViewportSize(): number;
   _getStartSpacerSize(): number;
   _getTotalSize(): number;
@@ -145,6 +125,7 @@ export type VirtualStore = {
 export const createVirtualStore = (
   elementsCount: number,
   itemSize: number = 40,
+  overscan: number = 4,
   ssrCount: number = 0,
   cacheSnapshot?: CacheSnapshot | undefined,
   shouldAutoEstimateItemSize: boolean = false
@@ -173,6 +154,7 @@ export const createVirtualStore = (
   );
   const subscribers = new Set<[number, Subscriber]>();
   const getRelativeScrollOffset = () => scrollOffset - startSpacerSize;
+  const getVisibleOffset = () => getRelativeScrollOffset() + pendingJump + jump;
   const getRange = (offset: number) => {
     return computeRange(cache, offset, viewportSize, _prevRange[0]);
   };
@@ -206,18 +188,25 @@ export const createVirtualStore = (
       if (_flushedJump) {
         return _prevRange;
       }
-      _prevRange = getRange(
-        max(0, getRelativeScrollOffset() + pendingJump + jump)
-      );
-
+      let [startIndex, endIndex] = getRange(max(0, getVisibleOffset()));
       if (_frozenRange) {
-        return [
-          min(_prevRange[0], _frozenRange[0]),
-          max(_prevRange[1], _frozenRange[1]),
-        ];
+        startIndex = min(startIndex, _frozenRange[0]);
+        endIndex = max(endIndex, _frozenRange[1]);
       }
-      return _prevRange;
+
+      if (_scrollDirection !== SCROLL_DOWN) {
+        startIndex -= max(0, overscan);
+      }
+      if (_scrollDirection !== SCROLL_UP) {
+        endIndex += max(0, overscan);
+      }
+      return (_prevRange = [
+        max(startIndex, 0),
+        min(endIndex, cache._length - 1),
+      ]);
     },
+    _getStartIndex: () => findIndex(cache, getVisibleOffset()),
+    _getEndIndex: () => findIndex(cache, getVisibleOffset() + viewportSize),
     _isUnmeasuredItem: (index) => cache._sizes[index] === UNCACHED,
     _hasUnmeasuredItemsInFrozenRange: () => {
       if (!_frozenRange) return false;
@@ -232,7 +221,7 @@ export const createVirtualStore = (
     _getItemSize: getItemSize,
     _getItemsLength: () => cache._length,
     _getScrollOffset: () => scrollOffset,
-    _getScrollDirection: () => _scrollDirection,
+    _isScrolling: () => _scrollDirection !== SCROLL_IDLE,
     _getViewportSize: () => viewportSize,
     _getStartSpacerSize: () => startSpacerSize,
     _getTotalSize: getTotalSize,
@@ -380,7 +369,12 @@ export const createVirtualStore = (
             // If the total size is lower than the viewport, the item may be a empty state
             _totalMeasuredSize > viewportSize
           ) {
-            applyJump(estimateDefaultItemSize(cache, _prevRange[0]));
+            applyJump(
+              estimateDefaultItemSize(
+                cache,
+                findIndex(cache, getVisibleOffset())
+              )
+            );
             shouldAutoEstimateItemSize = false;
           }
 

--- a/src/react/VList.tsx
+++ b/src/react/VList.tsx
@@ -29,7 +29,6 @@ export interface VListProps
       | "item"
       | "onScroll"
       | "onScrollEnd"
-      | "onRangeChange"
       | "keepMounted"
     >,
     ViewportComponentAttributes {
@@ -58,7 +57,6 @@ export const VList = forwardRef<VListHandle, VListProps>(
       item,
       onScroll,
       onScrollEnd,
-      onRangeChange,
       style,
       ...attrs
     },
@@ -82,7 +80,6 @@ export const VList = forwardRef<VListHandle, VListProps>(
         item={item}
         onScroll={onScroll}
         onScrollEnd={onScrollEnd}
-        onRangeChange={onRangeChange}
       >
         {children}
       </Virtualizer>

--- a/src/react/Virtualizer.tsx
+++ b/src/react/Virtualizer.tsx
@@ -3,17 +3,14 @@ import {
   forwardRef,
   useImperativeHandle,
   ReactNode,
-  useEffect,
   useRef,
   RefObject,
 } from "react";
 import {
   UPDATE_SCROLL_EVENT,
   ACTION_ITEMS_LENGTH_CHANGE,
-  getOverscanedRange,
   createVirtualStore,
   UPDATE_VIRTUAL_STATE,
-  SCROLL_IDLE,
   UPDATE_SCROLL_END_EVENT,
   getScrollSize,
   ACTION_START_OFFSET_CHANGE,
@@ -52,6 +49,14 @@ export interface VirtualizerHandle {
    * Get current offsetHeight, or offsetWidth if horizontal: true.
    */
   readonly viewportSize: number;
+  /**
+   * Get the start index of visible range of items.
+   */
+  readonly startIndex: number;
+  /**
+   * Get the end index of visible range of items.
+   */
+  readonly endIndex: number;
   /**
    * Get item offset from start.
    * @param index index of item
@@ -155,12 +160,6 @@ export interface VirtualizerProps {
    * Callback invoked when scrolling stops.
    */
   onScrollEnd?: () => void;
-  /**
-   * Callback invoked when visible items range changes.
-   * @param startIndex The start index of viewable items.
-   * @param endIndex The end index of viewable items.
-   */
-  onRangeChange?: (startIndex: number, endIndex: number) => void;
 }
 
 /**
@@ -171,7 +170,7 @@ export const Virtualizer = forwardRef<VirtualizerHandle, VirtualizerProps>(
     {
       children,
       count: renderCountProp,
-      overscan = 4,
+      overscan,
       itemSize,
       shift,
       horizontal: horizontalProp,
@@ -184,7 +183,6 @@ export const Virtualizer = forwardRef<VirtualizerHandle, VirtualizerProps>(
       scrollRef,
       onScroll: onScrollProp,
       onScrollEnd: onScrollEndProp,
-      onRangeChange: onRangeChangeProp,
     },
     ref
   ): ReactElement => {
@@ -204,6 +202,7 @@ export const Virtualizer = forwardRef<VirtualizerHandle, VirtualizerProps>(
       const _store = createVirtualStore(
         count,
         itemSize,
+        overscan,
         ssrCount,
         cache,
         !itemSize
@@ -227,19 +226,11 @@ export const Virtualizer = forwardRef<VirtualizerHandle, VirtualizerProps>(
     const rerender = useRerender(store);
 
     const [startIndex, endIndex] = store._getRange();
-    const scrollDirection = store._getScrollDirection();
+    const isScrolling = store._isScrolling();
     const jumpCount = store._getJumpCount();
     const totalSize = store._getTotalSize();
 
     const items: ReactElement[] = [];
-
-    const [overscanedRangeStart, overscanedRangeEnd] = getOverscanedRange(
-      startIndex,
-      endIndex,
-      overscan,
-      scrollDirection,
-      count
-    );
 
     const getListItem = (index: number) => {
       const e = getElement(index);
@@ -306,39 +297,35 @@ export const Virtualizer = forwardRef<VirtualizerHandle, VirtualizerProps>(
       scroller._fixScrollJump();
     }, [jumpCount]);
 
-    useEffect(() => {
-      if (!onRangeChangeProp) return;
+    useImperativeHandle(ref, () => {
+      return {
+        get cache() {
+          return store._getCacheSnapshot();
+        },
+        get scrollOffset() {
+          return store._getScrollOffset();
+        },
+        get scrollSize() {
+          return getScrollSize(store);
+        },
+        get viewportSize() {
+          return store._getViewportSize();
+        },
+        get startIndex() {
+          return store._getStartIndex();
+        },
+        get endIndex() {
+          return store._getEndIndex();
+        },
+        getItemOffset: store._getItemOffset,
+        getItemSize: store._getItemSize,
+        scrollToIndex: scroller._scrollToIndex,
+        scrollTo: scroller._scrollTo,
+        scrollBy: scroller._scrollBy,
+      };
+    }, []);
 
-      onRangeChangeProp(startIndex, endIndex);
-    }, [startIndex, endIndex]);
-
-    useImperativeHandle(
-      ref,
-      () => {
-        return {
-          get cache() {
-            return store._getCacheSnapshot();
-          },
-          get scrollOffset() {
-            return store._getScrollOffset();
-          },
-          get scrollSize() {
-            return getScrollSize(store);
-          },
-          get viewportSize() {
-            return store._getViewportSize();
-          },
-          getItemOffset: store._getItemOffset,
-          getItemSize: store._getItemSize,
-          scrollToIndex: scroller._scrollToIndex,
-          scrollTo: scroller._scrollTo,
-          scrollBy: scroller._scrollBy,
-        };
-      },
-      []
-    );
-
-    for (let i = overscanedRangeStart, j = overscanedRangeEnd; i <= j; i++) {
+    for (let i = startIndex, j = endIndex; i <= j; i++) {
       items.push(getListItem(i));
     }
 
@@ -346,10 +333,10 @@ export const Virtualizer = forwardRef<VirtualizerHandle, VirtualizerProps>(
       const startItems: ReactElement[] = [];
       const endItems: ReactElement[] = [];
       sort(keepMounted).forEach((index) => {
-        if (index < overscanedRangeStart) {
+        if (index < startIndex) {
           startItems.push(getListItem(index));
         }
-        if (index > overscanedRangeEnd) {
+        if (index > endIndex) {
           endItems.push(getListItem(index));
         }
       });
@@ -369,7 +356,7 @@ export const Virtualizer = forwardRef<VirtualizerHandle, VirtualizerProps>(
           visibility: "hidden", // TODO replace with other optimization methods
           width: isHorizontal ? totalSize : "100%",
           height: isHorizontal ? "100%" : totalSize,
-          pointerEvents: scrollDirection !== SCROLL_IDLE ? "none" : undefined,
+          pointerEvents: isScrolling ? "none" : undefined,
         }}
       >
         {items}

--- a/src/solid/VList.tsx
+++ b/src/solid/VList.tsx
@@ -29,7 +29,6 @@ export interface VListProps<T>
       | "horizontal"
       | "onScroll"
       | "onScrollEnd"
-      | "onRangeChange"
     >,
     ViewportComponentAttributes {}
 
@@ -47,7 +46,6 @@ export const VList = <T,>(props: VListProps<T>): JSX.Element => {
     horizontal,
     onScroll,
     onScrollEnd,
-    onRangeChange,
     style,
     ...attrs
   } = props;
@@ -73,7 +71,6 @@ export const VList = <T,>(props: VListProps<T>): JSX.Element => {
         horizontal={horizontal}
         onScroll={props.onScroll}
         onScrollEnd={props.onScrollEnd}
-        onRangeChange={props.onRangeChange}
       >
         {props.children}
       </Virtualizer>

--- a/src/solid/Virtualizer.tsx
+++ b/src/solid/Virtualizer.tsx
@@ -15,11 +15,9 @@ import {
 } from "solid-js";
 import { Dynamic } from "solid-js/web";
 import {
-  SCROLL_IDLE,
   UPDATE_SCROLL_EVENT,
   UPDATE_SCROLL_END_EVENT,
   UPDATE_VIRTUAL_STATE,
-  getOverscanedRange,
   createVirtualStore,
   ACTION_ITEMS_LENGTH_CHANGE,
   getScrollSize,
@@ -48,6 +46,14 @@ export interface VirtualizerHandle {
    * Get current offsetHeight, or offsetWidth if horizontal: true.
    */
   readonly viewportSize: number;
+  /**
+   * Get the start index of visible range of items.
+   */
+  readonly startIndex: number;
+  /**
+   * Get the end index of visible range of items.
+   */
+  readonly endIndex: number;
   /**
    * Get item offset from start.
    * @param index index of item
@@ -139,12 +145,6 @@ export interface VirtualizerProps<T> {
    * Callback invoked when scrolling stops.
    */
   onScrollEnd?: () => void;
-  /**
-   * Callback invoked when visible items range changes.
-   * @param startIndex The start index of viewable items.
-   * @param endIndex The end index of viewable items.
-   */
-  onRangeChange?: (startIndex: number, endIndex: number) => void;
 }
 
 /**
@@ -152,7 +152,7 @@ export interface VirtualizerProps<T> {
  */
 export const Virtualizer = <T,>(props: VirtualizerProps<T>): JSX.Element => {
   let containerRef: HTMLDivElement | undefined;
-  const { itemSize, horizontal = false } = props;
+  const { itemSize, horizontal = false, overscan } = props;
   props = mergeProps<[Partial<VirtualizerProps<T>>, VirtualizerProps<T>]>(
     { as: "div" },
     props
@@ -161,6 +161,7 @@ export const Virtualizer = <T,>(props: VirtualizerProps<T>): JSX.Element => {
   const store = createVirtualStore(
     props.data.length,
     itemSize,
+    overscan,
     undefined,
     undefined,
     !itemSize
@@ -192,28 +193,10 @@ export const Virtualizer = <T,>(props: VirtualizerProps<T>): JSX.Element => {
     }
     return next;
   });
-  const scrollDirection = createMemo(
-    () => rerender() && store._getScrollDirection()
-  );
+  const isScrolling = createMemo(() => rerender() && store._isScrolling());
   const totalSize = createMemo(() => rerender() && store._getTotalSize());
 
   const jumpCount = createMemo(() => rerender() && store._getJumpCount());
-
-  const overscanedRange = createMemo<ItemsRange>((prev) => {
-    const overscan = props.overscan ?? 4;
-    const [startIndex, endIndex] = range();
-    const next = getOverscanedRange(
-      startIndex,
-      endIndex,
-      overscan,
-      scrollDirection(),
-      props.data.length
-    );
-    if (prev && isSameRange(prev, next)) {
-      return prev;
-    }
-    return next;
-  });
 
   onMount(() => {
     if (props.ref) {
@@ -226,6 +209,12 @@ export const Virtualizer = <T,>(props: VirtualizerProps<T>): JSX.Element => {
         },
         get viewportSize() {
           return store._getViewportSize();
+        },
+        get startIndex() {
+          return store._getStartIndex();
+        },
+        get endIndex() {
+          return store._getEndIndex();
         },
         getItemOffset: store._getItemOffset,
         getItemSize: store._getItemSize,
@@ -280,11 +269,6 @@ export const Virtualizer = <T,>(props: VirtualizerProps<T>): JSX.Element => {
     })
   );
 
-  createEffect(() => {
-    const next = range();
-    props.onRangeChange && props.onRangeChange(next[0], next[1]);
-  });
-
   return (
     <Dynamic
       component={props.as}
@@ -297,13 +281,12 @@ export const Virtualizer = <T,>(props: VirtualizerProps<T>): JSX.Element => {
         visibility: "hidden", // TODO replace with other optimization methods
         width: horizontal ? totalSize() + "px" : "100%",
         height: horizontal ? "100%" : totalSize() + "px",
-        "pointer-events":
-          scrollDirection() !== SCROLL_IDLE ? "none" : undefined,
+        "pointer-events": isScrolling() ? "none" : undefined,
       }}
     >
       <RangedFor
         _each={props.data}
-        _range={overscanedRange()}
+        _range={range()}
         _render={(data, index) => {
           const offset = createMemo(() => {
             rerender();

--- a/src/solid/WindowVirtualizer.tsx
+++ b/src/solid/WindowVirtualizer.tsx
@@ -12,12 +12,11 @@ import {
   createComputed,
 } from "solid-js";
 import {
-  SCROLL_IDLE,
   UPDATE_SCROLL_END_EVENT,
   UPDATE_VIRTUAL_STATE,
-  getOverscanedRange,
   createVirtualStore,
   ACTION_ITEMS_LENGTH_CHANGE,
+  UPDATE_SCROLL_EVENT,
 } from "../core/store";
 import { createWindowResizer } from "../core/resizer";
 import { createWindowScroller } from "../core/scroller";
@@ -26,19 +25,28 @@ import { RangedFor } from "./RangedFor";
 import { isSameRange } from "./utils";
 import { ItemsRange } from "../core/types";
 
-// /**
-//  * Methods of {@link WindowVirtualizer}.
-//  */
-// export interface WindowVirtualizerHandle {}
+/**
+ * Methods of {@link WindowVirtualizer}.
+ */
+export interface WindowVirtualizerHandle {
+  /**
+   * Get the start index of visible range of items.
+   */
+  readonly startIndex: number;
+  /**
+   * Get the end index of visible range of items.
+   */
+  readonly endIndex: number;
+}
 
 /**
  * Props of {@link WindowVirtualizer}.
  */
 export interface WindowVirtualizerProps<T> {
-  // /**
-  //  * Get reference to {@link WindowVirtualizerHandle}.
-  //  */
-  // ref?: (handle?: WindowVirtualizerHandle) => void;
+  /**
+   * Get reference to {@link WindowVirtualizerHandle}.
+   */
+  ref?: (handle?: WindowVirtualizerHandle) => void;
   /**
    * The data items rendered by this component.
    */
@@ -68,15 +76,14 @@ export interface WindowVirtualizerProps<T> {
    */
   horizontal?: boolean;
   /**
+   * Callback invoked whenever scroll offset changes.
+   * @param offset Current scrollTop, or scrollLeft if horizontal: true.
+   */
+  onScroll?: (offset: number) => void;
+  /**
    * Callback invoked when scrolling stops.
    */
   onScrollEnd?: () => void;
-  /**
-   * Callback invoked when visible items range changes.
-   * @param startIndex The start index of viewable items.
-   * @param endIndex The end index of viewable items.
-   */
-  onRangeChange?: (startIndex: number, endIndex: number) => void;
 }
 
 /**
@@ -88,20 +95,20 @@ export const WindowVirtualizer = <T,>(
   let containerRef: HTMLDivElement | undefined;
 
   const {
-    // ref: _ref,
+    ref: _ref,
     data: _data,
     children: _children,
-    overscan: _overscan,
+    overscan,
     itemSize,
     shift: _shift,
     horizontal = false,
     onScrollEnd: _onScrollEnd,
-    onRangeChange: _onRangeChange,
   } = props;
 
   const store = createVirtualStore(
     props.data.length,
     itemSize,
+    overscan,
     undefined,
     undefined,
     !itemSize
@@ -115,6 +122,9 @@ export const WindowVirtualizer = <T,>(
     setRerender(store._getStateVersion());
   });
 
+  const unsubscribeOnScroll = store._subscribe(UPDATE_SCROLL_EVENT, () => {
+    props.onScroll?.(store._getScrollOffset());
+  });
   const unsubscribeOnScrollEnd = store._subscribe(
     UPDATE_SCROLL_END_EVENT,
     () => {
@@ -130,35 +140,33 @@ export const WindowVirtualizer = <T,>(
     }
     return next;
   });
-  const scrollDirection = createMemo(
-    () => rerender() && store._getScrollDirection()
-  );
+  const isScrolling = createMemo(() => rerender() && store._isScrolling());
   const totalSize = createMemo(() => rerender() && store._getTotalSize());
 
   const jumpCount = createMemo(() => rerender() && store._getJumpCount());
 
-  const overscanedRange = createMemo<ItemsRange>((prev) => {
-    const overscan = props.overscan ?? 4;
-    const [startIndex, endIndex] = range();
-    const next = getOverscanedRange(
-      startIndex,
-      endIndex,
-      overscan,
-      scrollDirection(),
-      props.data.length
-    );
-    if (prev && isSameRange(prev, next)) {
-      return prev;
-    }
-    return next;
-  });
-
   onMount(() => {
+    if (props.ref) {
+      props.ref({
+        get startIndex() {
+          return store._getStartIndex();
+        },
+        get endIndex() {
+          return store._getEndIndex();
+        },
+      });
+    }
+
     resizer._observeRoot(containerRef!);
     scroller._observe(containerRef!);
 
     onCleanup(() => {
+      if (props.ref) {
+        props.ref();
+      }
+
       unsubscribeStore();
+      unsubscribeOnScroll();
       unsubscribeOnScrollEnd();
       resizer._dispose();
       scroller._dispose();
@@ -182,11 +190,6 @@ export const WindowVirtualizer = <T,>(
     })
   );
 
-  createEffect(() => {
-    const next = range();
-    props.onRangeChange && props.onRangeChange(next[0], next[1]);
-  });
-
   return (
     <div
       ref={containerRef}
@@ -198,13 +201,12 @@ export const WindowVirtualizer = <T,>(
         visibility: "hidden", // TODO replace with other optimization methods
         width: horizontal ? totalSize() + "px" : "100%",
         height: horizontal ? "100%" : totalSize() + "px",
-        "pointer-events":
-          scrollDirection() !== SCROLL_IDLE ? "none" : undefined,
+        "pointer-events": isScrolling() ? "none" : undefined,
       }}
     >
       <RangedFor
         _each={props.data}
-        _range={overscanedRange()}
+        _range={range()}
         _render={(data, index) => {
           const offset = createMemo(() => {
             rerender();

--- a/src/solid/index.ts
+++ b/src/solid/index.ts
@@ -8,5 +8,5 @@ export type { VirtualizerProps, VirtualizerHandle } from "./Virtualizer";
 export { WindowVirtualizer } from "./WindowVirtualizer";
 export type {
   WindowVirtualizerProps,
-  // WindowVirtualizerHandle,
+  WindowVirtualizerHandle,
 } from "./WindowVirtualizer";

--- a/src/svelte/VList.svelte
+++ b/src/svelte/VList.svelte
@@ -15,7 +15,6 @@
     children,
     onscroll,
     onscrollend,
-    onrangechange,
     ...rest
   }: Props = $props();
 
@@ -27,6 +26,10 @@
     ref.getScrollSize()) satisfies VListHandle["getScrollSize"] as VListHandle["getScrollSize"];
   export const getViewportSize = (() =>
     ref.getViewportSize()) satisfies VListHandle["getViewportSize"] as VListHandle["getViewportSize"];
+  export const getStartIndex = (() =>
+    ref.getStartIndex()) satisfies VListHandle["getStartIndex"] as VListHandle["getStartIndex"];
+  export const getEndIndex = (() =>
+    ref.getEndIndex()) satisfies VListHandle["getEndIndex"] as VListHandle["getEndIndex"];
   export const getItemOffset = ((...args) =>
     ref.getItemOffset(
       ...args
@@ -73,6 +76,5 @@
     {horizontal}
     {onscroll}
     {onscrollend}
-    {onrangechange}
   />
 </div>

--- a/src/svelte/VList.type.ts
+++ b/src/svelte/VList.type.ts
@@ -16,7 +16,6 @@ export interface VListProps<T>
       | "children"
       | "onscroll"
       | "onscrollend"
-      | "onrangechange"
     >,
     ViewportComponentAttributes {}
 

--- a/src/svelte/Virtualizer.type.ts
+++ b/src/svelte/Virtualizer.type.ts
@@ -66,12 +66,6 @@ export interface VirtualizerProps<T> {
    * Callback invoked when scrolling stops.
    */
   onscrollend?: () => void;
-  /**
-   * Callback invoked when visible items range changes.
-   * @param startIndex The start index of viewable items.
-   * @param endIndex The end index of viewable items.
-   */
-  onrangechange?: (startIndex: number, endIndex: number) => void;
 }
 
 /**
@@ -90,6 +84,14 @@ export interface VirtualizerHandle {
    * Get current offsetHeight, or offsetWidth if horizontal: true.
    */
   getViewportSize: () => number;
+  /**
+   * Get the start index of visible range of items.
+   */
+  getStartIndex: () => number;
+  /**
+   * Get the end index of visible range of items.
+   */
+  getEndIndex: () => number;
   /**
    * Get item offset from start.
    * @param index index of item

--- a/src/svelte/WindowVirtualizer.type.ts
+++ b/src/svelte/WindowVirtualizer.type.ts
@@ -38,23 +38,26 @@ export interface WindowVirtualizerProps<T> {
    */
   horizontal?: boolean;
   /**
+   * Callback invoked whenever scroll offset changes.
+   * @param offset Current scrollTop, or scrollLeft if horizontal: true.
+   */
+  onscroll?: (offset: number) => void;
+  /**
    * Callback invoked when scrolling stops.
    */
   onscrollend?: () => void;
-  /**
-   * Callback invoked when visible items range changes.
-   * @param startIndex The start index of viewable items.
-   * @param endIndex The end index of viewable items.
-   */
-  onrangechange?: (startIndex: number, endIndex: number) => void;
 }
 
-// /**
-//  * Methods of {@link WindowVirtualizer}.
-//  */
-// export interface WindowVirtualizerHandle {
-//   /**
-//    * Get current {@link CacheSnapshot}.
-//    */
-//   readonly cache: CacheSnapshot;
-// }
+/**
+ * Methods of {@link WindowVirtualizer}.
+ */
+export interface WindowVirtualizerHandle {
+  /**
+   * Get the start index of visible range of items.
+   */
+  getStartIndex: () => number;
+  /**
+   * Get the end index of visible range of items.
+   */
+  getEndIndex: () => number;
+}

--- a/src/vue/VList.tsx
+++ b/src/vue/VList.tsx
@@ -21,7 +21,7 @@ const props = {
    * Number of items to render above/below the visible bounds of the list. You can increase to avoid showing blank items in fast scrolling.
    * @defaultValue 4
    */
-  overscan: { type: Number, default: 4 },
+  overscan: Number,
   /**
    * Item size hint for unmeasured items. It will help to reduce scroll jump when items are measured if used properly.
    *
@@ -45,7 +45,7 @@ const props = {
 
 export const VList = /*#__PURE__*/ defineComponent({
   props: props,
-  emits: ["scroll", "scrollEnd", "rangeChange"],
+  emits: ["scroll", "scrollEnd"],
   setup(props, { emit, expose, slots }) {
     const horizontal = props.horizontal;
 
@@ -54,9 +54,6 @@ export const VList = /*#__PURE__*/ defineComponent({
     };
     const onScrollEnd = () => {
       emit("scrollEnd");
-    };
-    const onRangeChange = (start: number, end: number) => {
-      emit("rangeChange", start, end);
     };
 
     const handle = ref<InstanceType<typeof Virtualizer>>();
@@ -70,6 +67,12 @@ export const VList = /*#__PURE__*/ defineComponent({
       },
       get viewportSize() {
         return handle.value!.viewportSize;
+      },
+      get startIndex() {
+        return handle.value!.startIndex;
+      },
+      get endIndex() {
+        return handle.value!.endIndex;
       },
       getItemOffset: (...args) => handle.value!.getItemOffset(...args),
       getItemSize: (...args) => handle.value!.getItemSize(...args),
@@ -99,7 +102,6 @@ export const VList = /*#__PURE__*/ defineComponent({
             horizontal={horizontal}
             onScroll={onScroll}
             onScrollEnd={onScrollEnd}
-            onRangeChange={onRangeChange}
           >
             {slots}
           </Virtualizer>
@@ -125,12 +127,6 @@ export const VList = /*#__PURE__*/ defineComponent({
      * Callback invoked when scrolling stops.
      */
     scrollEnd: () => void;
-    /**
-     * Callback invoked when visible items range changes.
-     * @param startIndex The start index of viewable items.
-     * @param endIndex The end index of viewable items.
-     */
-    rangeChange: (startIndex: number, endIndex: number) => void;
   },
   string,
   {},

--- a/stories/react/advanced/Feed.stories.tsx
+++ b/stories/react/advanced/Feed.stories.tsx
@@ -103,15 +103,20 @@ export const Default: StoryObj = {
         ref={ref}
         style={{ flex: 1 }}
         shift={shifting ? true : false}
-        onRangeChange={async (start, end) => {
+        onScroll={async () => {
           if (!ready.current) return;
-          if (end + THRESHOLD > count && endFetchedCountRef.current < count) {
+          if (!ref.current) return;
+
+          if (
+            endFetchedCountRef.current < count &&
+            ref.current.endIndex + THRESHOLD > count
+          ) {
             endFetchedCountRef.current = count;
             await fetchItems();
             setItems((prev) => [...prev, ...createItems(ITEM_BATCH_COUNT)]);
           } else if (
-            start - THRESHOLD < 0 &&
-            startFetchedCountRef.current < count
+            startFetchedCountRef.current < count &&
+            ref.current.startIndex - THRESHOLD < 0
           ) {
             startFetchedCountRef.current = count;
             await fetchItems(true);

--- a/stories/react/advanced/Sticky Group.stories.tsx
+++ b/stories/react/advanced/Sticky Group.stories.tsx
@@ -1,6 +1,12 @@
 import { Meta, StoryObj } from "@storybook/react";
-import React, { createContext, forwardRef, useContext, useState } from "react";
-import { CustomItemComponentProps, VList } from "../../../src";
+import React, {
+  createContext,
+  forwardRef,
+  useContext,
+  useRef,
+  useState,
+} from "react";
+import { CustomItemComponentProps, VList, VListHandle } from "../../../src";
 
 export default {
   component: VList,
@@ -35,13 +41,17 @@ const StickyItem = forwardRef<HTMLDivElement, CustomItemComponentProps>(
 export const Default: StoryObj = {
   name: "Sticky Group",
   render: () => {
+    const ref = useRef<VListHandle>(null);
     const [activeIndex, setActiveIndex] = useState(0);
     return (
       <StickyIndexContext.Provider value={activeIndex}>
         <VList
+          ref={ref}
           item={StickyItem}
           keepMounted={[activeIndex]}
-          onRangeChange={(start) => {
+          onScroll={() => {
+            if (!ref.current) return;
+            const start = ref.current.startIndex;
             const activeStickyIndex = [...stickyIndexes]
               .reverse()
               .find((index) => start >= index)!;

--- a/stories/react/basics/VList.stories.tsx
+++ b/stories/react/basics/VList.stories.tsx
@@ -553,6 +553,8 @@ export const InfiniteScrolling: StoryObj = {
       setFetching(false);
     };
 
+    const ref = useRef<VListHandle>(null);
+
     const ITEM_BATCH_COUNT = 100;
     const [items, setItems] = useState(() => createRows(ITEM_BATCH_COUNT));
     const fetchedCountRef = useRef(-1);
@@ -560,9 +562,14 @@ export const InfiniteScrolling: StoryObj = {
 
     return (
       <VList
+        ref={ref}
         style={{ flex: 1 }}
-        onRangeChange={async (_, end) => {
-          if (end + 50 > count && fetchedCountRef.current < count) {
+        onScroll={async () => {
+          if (!ref.current) return;
+          if (
+            fetchedCountRef.current < count &&
+            ref.current.endIndex + 50 > count
+          ) {
             fetchedCountRef.current = count;
             await fetchItems();
             setItems((prev) => [
@@ -585,7 +592,8 @@ export const Statuses: StoryObj = {
     const items = useState(() => createRows(1000))[0];
     const [position, setPosition] = useState(0);
     const [scrolling, setScrolling] = useState(false);
-    const [range, setRange] = useState([-1, -1]);
+    const [startIndex, setStartIndex] = useState(-1);
+    const [endIndex, setEndIndex] = useState(-1);
 
     const [isAtTop, setIsAtTop] = useState(false);
     const [isAtBottom, setIsAtBottom] = useState(false);
@@ -623,7 +631,7 @@ export const Statuses: StoryObj = {
           <div>scrollTop: {position}</div>
           <div>scrolling: {scrolling ? "true" : "false"}</div>
           <div>
-            index: ({range[0]}, {range[1]})
+            index: ({startIndex}, {endIndex})
           </div>
           <div>at top: {isAtTop ? "true" : "false"}</div>
           <div>at bottom: {isAtBottom ? "true" : "false"}</div>
@@ -635,16 +643,14 @@ export const Statuses: StoryObj = {
             startTransition(() => {
               setPosition(offset);
               setScrolling(true);
+              if (!ref.current) return;
+              setStartIndex(ref.current.startIndex);
+              setEndIndex(ref.current.endIndex);
             });
           }}
           onScrollEnd={() => {
             startTransition(() => {
               setScrolling(false);
-            });
-          }}
-          onRangeChange={async (start, end) => {
-            startTransition(() => {
-              setRange([start, end]);
             });
           }}
         >

--- a/stories/react/basics/Virtualizer.stories.tsx
+++ b/stories/react/basics/Virtualizer.stories.tsx
@@ -198,15 +198,20 @@ export const BiDirectionalInfiniteScrolling: StoryObj = {
           ref={ref}
           shift={shifting ? true : false}
           startMargin={spinnerHeight}
-          onRangeChange={async (start, end) => {
+          onScroll={async () => {
             if (!ready.current) return;
-            if (end + THRESHOLD > count && endFetchedCountRef.current < count) {
+            if (!ref.current) return;
+
+            if (
+              endFetchedCountRef.current < count &&
+              ref.current.endIndex + THRESHOLD > count
+            ) {
               endFetchedCountRef.current = count;
               await fetchItems();
               setItems((prev) => [...prev, ...createRows(ITEM_BATCH_COUNT)]);
             } else if (
-              start - THRESHOLD < 0 &&
-              startFetchedCountRef.current < count
+              startFetchedCountRef.current < count &&
+              ref.current.startIndex - THRESHOLD < 0
             ) {
               startFetchedCountRef.current = count;
               await fetchItems(true);

--- a/stories/react/basics/WindowVirtualizer.stories.tsx
+++ b/stories/react/basics/WindowVirtualizer.stories.tsx
@@ -168,11 +168,18 @@ export const InfiniteScrolling: StoryObj = {
     const fetchedCountRef = useRef(-1);
     const count = items.length;
 
+    const ref = useRef<WindowVirtualizerHandle>(null);
+
     return (
       <div style={{ padding: "200px 100px 0px 100px" }}>
         <WindowVirtualizer
-          onRangeChange={async (_, end) => {
-            if (end + 50 > count && fetchedCountRef.current < count) {
+          ref={ref}
+          onScroll={async () => {
+            if (!ref.current) return;
+            if (
+              fetchedCountRef.current < count &&
+              ref.current.endIndex + 50 > count
+            ) {
               fetchedCountRef.current = count;
               await fetchItems();
               setItems((prev) => [


### PR DESCRIPTION
#378 

This PR removes `onRangeChange` prop because it is an obstacle to achieving #378 . 
Instead, this PR adds `startIndex`/`endIndex` getter to handles and `onScroll` to WindowVirtualizer, that opens more flexible configuration.