### PR TITLE
Fix reactivity issue on length change in Vue/Solid/Svelte

### DIFF
--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -397,17 +397,14 @@ export const createVirtualStore = (
           break;
         }
         case ACTION_ITEMS_LENGTH_CHANGE: {
-          const atBottom = scrollOffset + viewportSize >= getTotalSize();
-
           if (payload[1]) {
             applyJump(updateCacheLength(cache, payload[0], true));
             _scrollMode = SCROLL_BY_SHIFT;
+            mutated = UPDATE_VIRTUAL_STATE;
           } else {
             updateCacheLength(cache, payload[0]);
-          }
-
-          // https://github.com/inokawa/virtua/issues/552
-          if (payload[1] || atBottom) {
+            // https://github.com/inokawa/virtua/issues/552
+            // https://github.com/inokawa/virtua/issues/557
             mutated = UPDATE_VIRTUAL_STATE;
           }
           break;


### PR DESCRIPTION
fix #557 

It seems that Vue/Solid/Svelte batch rendering on update so just update state, for consistency. 