### PR TITLE
feat: export cancelScroll handle

### DIFF
--- a/src/core/scroller.ts
+++ b/src/core/scroller.ts
@@ -186,6 +186,7 @@ export type Scroller = {
   $scrollBy: (offset: number) => void;
   $scrollToIndex: (index: number, opts?: ScrollToIndexOpts) => void;
   $fixScrollJump: () => void;
+  $cancelScroll: () => void;
 };
 
 /**
@@ -368,6 +369,9 @@ export const createScroller = (
     },
     $fixScrollJump: () => {
       scrollObserver && scrollObserver._fixScrollJump();
+    },
+    $cancelScroll: () => {
+      cancelScroll && cancelScroll();
     },
   };
 };
@@ -581,11 +585,11 @@ export const createWindowScroller = (
           store.$getItemOffset(index) +
           (align === "end"
             ? store.$getItemSize(index) -
-              (store.$getViewportSize() - getScrollbarSize())
+            (store.$getViewportSize() - getScrollbarSize())
             : align === "center"
               ? (store.$getItemSize(index) -
-                  (store.$getViewportSize() - getScrollbarSize())) /
-                2
+                (store.$getViewportSize() - getScrollbarSize())) /
+              2
               : 0)
         );
       }, smooth);

--- a/src/react/Virtualizer.tsx
+++ b/src/react/Virtualizer.tsx
@@ -86,6 +86,10 @@ export interface VirtualizerHandle {
    * @param offset offset from current position
    */
   scrollBy(offset: number): void;
+  /**
+   * Cancel unfinished scroll.
+   */
+  cancelScroll(): void;
 }
 
 /**
@@ -321,6 +325,7 @@ export const Virtualizer = forwardRef<VirtualizerHandle, VirtualizerProps>(
         scrollToIndex: scroller.$scrollToIndex,
         scrollTo: scroller.$scrollTo,
         scrollBy: scroller.$scrollBy,
+        cancelScroll: scroller.$cancelScroll,
       };
     }, []);
 


### PR DESCRIPTION
I am creating a AI Chat like app, the last item is growing height when AI generate some message.

At a very special moment (not always reproducible), when last item is growing height, I use the wheel to scroll up, the scrollbar will first scroll up and then immediately snap to the bottom.

After doing some research, this is caused by `waitForMeasurement`: when user trigger a `scrollToIndex`, virtua will do scroll and listen for `UPDATE_SIZE_EVENT` event within the next 150ms, if at the same time the last item is resizing, it will fire an action `ACTION_ITEM_RESIZE` to **make scroller to scroll to the lastest position**. So if a user scrolls up within this 150ms, their operation will be overwritten by the latest scroll to the bottom.