### PR TITLE
Remove unnecessary awaits and variables from tests

### DIFF
--- a/e2e/VList.spec.ts
+++ b/e2e/VList.spec.ts
@@ -465,7 +465,7 @@ test.describe("check if scroll jump compensation works", () => {
     await clearTimer(page);
 
     const button = page.getByRole("button", { name: "submit" });
-    const textarea = (await page.getByRole("textbox"))!;
+    const textarea = page.getByRole("textbox")!;
 
     // append small item
     await button.click();
@@ -969,8 +969,8 @@ test.describe("check if item shift compensation works", () => {
     ]);
 
     await page.getByRole("checkbox", { name: "prepend" }).click();
-    const decreaseRadio = await page.getByRole("radio", { name: "decrease" });
-    const increaseRadio = await page.getByRole("radio", { name: "increase" });
+    const decreaseRadio = page.getByRole("radio", { name: "decrease" });
+    const increaseRadio = page.getByRole("radio", { name: "increase" });
     const valueInput = page.getByRole("spinbutton");
     const updateButton = page.getByRole("button", { name: "update" });
 
@@ -1042,8 +1042,8 @@ test.describe("check if item shift compensation works", () => {
     await page.getByRole("checkbox", { name: "reverse" }).click();
 
     await page.getByRole("checkbox", { name: "prepend" }).click();
-    const decreaseRadio = await page.getByRole("radio", { name: "decrease" });
-    const increaseRadio = await page.getByRole("radio", { name: "increase" });
+    const decreaseRadio = page.getByRole("radio", { name: "decrease" });
+    const increaseRadio = page.getByRole("radio", { name: "increase" });
     const valueInput = page.getByRole("spinbutton");
     const updateButton = page.getByRole("button", { name: "update" });
 
@@ -1117,8 +1117,8 @@ test.describe("check if item shift compensation works", () => {
     await page.getByRole("checkbox", { name: "reverse" }).click();
 
     await page.getByRole("checkbox", { name: "prepend" }).click();
-    const decreaseRadio = await page.getByRole("radio", { name: "decrease" });
-    const increaseRadio = await page.getByRole("radio", { name: "increase" });
+    const decreaseRadio = page.getByRole("radio", { name: "decrease" });
+    const increaseRadio = page.getByRole("radio", { name: "increase" });
     const valueInput = page.getByRole("spinbutton");
     const updateButton = page.getByRole("button", { name: "update" });
 

--- a/e2e/Virtualizer.spec.ts
+++ b/e2e/Virtualizer.spec.ts
@@ -29,7 +29,7 @@ test("header and footer", async ({ page }) => {
   const itemsSelector = '*[style*="top"]';
 
   // check if start is displayed
-  const topItem = await container.locator(itemsSelector).first();
+  const topItem = container.locator(itemsSelector).first();
   expect(await topItem.textContent()).toEqual("0");
   expect(
     await (async () => {
@@ -77,7 +77,7 @@ test("sticky header and footer", async ({ page }) => {
   const itemsSelector = '*[style*="top"]';
 
   // check if start is displayed
-  const topItem = await container.locator(itemsSelector).first();
+  const topItem = container.locator(itemsSelector).first();
   expect(await topItem.textContent()).toEqual("0");
   expect(
     await (async () => {
@@ -92,7 +92,7 @@ test("sticky header and footer", async ({ page }) => {
 
   // check if the end is displayed
   const items = container.locator(itemsSelector);
-  const bottomItem = await items.last();
+  const bottomItem = items.last();
   expect(await bottomItem.textContent()).toEqual("999");
   expectInRange(
     await (async () => {

--- a/e2e/WindowVirtualizer.spec.ts
+++ b/e2e/WindowVirtualizer.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, ElementHandle } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import {
   storyUrl,
   getFirstItem,
@@ -190,8 +190,6 @@ test.describe("check if item shift compensation works", () => {
   });
 
   test("keep end at mid when add to/remove from end", async ({ page }) => {
-    const component = await getVirtualizer(page);
-
     const updateButton = page.getByRole("button", { name: "update" });
 
     // fill list and move to mid
@@ -222,8 +220,6 @@ test.describe("check if item shift compensation works", () => {
   });
 
   test("keep start at mid when add to/remove from start", async ({ page }) => {
-    const component = await getVirtualizer(page);
-
     const updateButton = page.getByRole("button", { name: "update" });
 
     // fill list and move to mid
@@ -261,8 +257,8 @@ test.describe("check if item shift compensation works", () => {
     const component = await getVirtualizer(page);
 
     await page.getByRole("checkbox", { name: "prepend" }).click();
-    const decreaseRadio = await page.getByRole("radio", { name: "decrease" });
-    const increaseRadio = await page.getByRole("radio", { name: "increase" });
+    const decreaseRadio = page.getByRole("radio", { name: "decrease" });
+    const increaseRadio = page.getByRole("radio", { name: "increase" });
     const valueInput = page.getByRole("spinbutton");
     const updateButton = page.getByRole("button", { name: "update" });
 
@@ -324,8 +320,8 @@ test.describe("check if item shift compensation works", () => {
     const component = await getVirtualizer(page);
 
     await page.getByRole("checkbox", { name: "prepend" }).click();
-    const decreaseRadio = await page.getByRole("radio", { name: "decrease" });
-    const increaseRadio = await page.getByRole("radio", { name: "increase" });
+    const decreaseRadio = page.getByRole("radio", { name: "decrease" });
+    const increaseRadio = page.getByRole("radio", { name: "increase" });
     const valueInput = page.getByRole("spinbutton");
     const updateButton = page.getByRole("button", { name: "update" });
 

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -12,7 +12,7 @@ export const getScrollable = async (page: Page) => {
 };
 
 export const getVirtualizer = async (page: Page) => {
-  const locator = await page.locator('*[style*="flex: 0 0 auto"]');
+  const locator = page.locator('*[style*="flex: 0 0 auto"]');
   await locator.evaluate((e) => (e.style.visibility = "visible"));
   await locator.waitFor();
   return locator;


### PR DESCRIPTION
Unnecessary await was used on non-async functions and detected by typescript via lsp.