### PR TITLE
fix: handle resize for vgrid

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -51,7 +51,7 @@ export default process.env.STORYBOOK_VUE
         }
       : {
           stories: ["../stories/react/**/*.stories.@(js|jsx|ts|tsx)"],
-          addons: ["@storybook/addon-storysource"],
+          addons: ["@storybook/addon-storysource", "@storybook/addon-viewport"],
           framework: {
             name: "@storybook/react-vite",
             options: {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@rollup/plugin-typescript": "^11.1.6",
         "@size-limit/preset-small-lib": "^11.1.6",
         "@storybook/addon-storysource": "^8.6.2",
+        "@storybook/addon-viewport": "^8.6.4",
         "@storybook/docs-tools": "^8.6.2",
         "@storybook/react": "^8.6.2",
         "@storybook/react-vite": "^8.6.2",
@@ -5344,6 +5345,22 @@
         "storybook": "^8.6.2"
       }
     },
+    "node_modules/@storybook/addon-viewport": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-8.6.4.tgz",
+      "integrity": "sha512-O5Ij+SRVg6grY6JOL5lOpsFyopZxuZEl2GHfh2SUf9hfowNS0QAgFpJupqXkwZzRSrlf9uKrLkjB6ulLgN2gOQ==",
+      "dev": true,
+      "dependencies": {
+        "memoizerific": "^1.11.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.4"
+      }
+    },
     "node_modules/@storybook/builder-vite": {
       "version": "8.6.2",
       "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-8.6.2.tgz",
@@ -5377,12 +5394,12 @@
       }
     },
     "node_modules/@storybook/core": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.6.2.tgz",
-      "integrity": "sha512-i8a/nUuzzH5RLKjPn8DM7l8xxuTdLZ6xbI4hgpruas3JY8lQq72I7qmH6pmI7ByjGangDWK1iPh+tghdKkS6KQ==",
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.6.4.tgz",
+      "integrity": "sha512-glDbjEBi3wokw1T+KQtl93irHO9N0LCwgylWfWVXYDdQjUJ7pGRQGnw73gPX7Ds9tg3myXFC83GjmY94UYSMbA==",
       "dev": true,
       "dependencies": {
-        "@storybook/theming": "8.6.2",
+        "@storybook/theming": "8.6.4",
         "better-opn": "^3.0.2",
         "browser-assert": "^1.2.1",
         "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0",
@@ -5405,6 +5422,19 @@
         "prettier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@storybook/theming": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.6.4.tgz",
+      "integrity": "sha512-g9Ns4uenC9oAWETaJ/tEKEIPMdS+CqjNWZz5Wbw1bLNhXwADZgKrVqawzZi64+bYYtQ+i8VCTjPoFa6s2eHiDQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
       }
     },
     "node_modules/@storybook/core/node_modules/semver": {
@@ -15711,6 +15741,12 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/map-or-similar": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
+      "integrity": "sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==",
+      "dev": true
+    },
     "node_modules/markdown-it": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
@@ -15770,6 +15806,15 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "dev": true
+    },
+    "node_modules/memoizerific": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
+      "integrity": "sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==",
+      "dev": true,
+      "dependencies": {
+        "map-or-similar": "^1.5.0"
+      }
     },
     "node_modules/merge-anything": {
       "version": "5.1.7",
@@ -18670,12 +18715,12 @@
       }
     },
     "node_modules/storybook": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.6.2.tgz",
-      "integrity": "sha512-IkQGRNImyN14+tx/9KLg9k5xKBgrkWaPFhfwTCxUZUzLNClbVrxkkXyjFaks9kPVQIEUVPGQCiGFqypUiwoM6g==",
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.6.4.tgz",
+      "integrity": "sha512-XXh1Acvf1r3BQX0BDLQw6yhZ7yUGvYxIcKOBuMdetnX7iXtczipJTfw0uyFwk0ltkKEE9PpJvivYmARF3u64VQ==",
       "dev": true,
       "dependencies": {
-        "@storybook/core": "8.6.2"
+        "@storybook/core": "8.6.4"
       },
       "bin": {
         "getstorybook": "bin/index.cjs",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@rollup/plugin-typescript": "^11.1.6",
     "@size-limit/preset-small-lib": "^11.1.6",
     "@storybook/addon-storysource": "^8.6.2",
+    "@storybook/addon-viewport": "^8.6.4",
     "@storybook/docs-tools": "^8.6.2",
     "@storybook/react": "^8.6.2",
     "@storybook/react-vite": "^8.6.2",

--- a/stories/react/basics/VGrid.stories.tsx
+++ b/stories/react/basics/VGrid.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react";
-import React, { useRef, useState } from "react";
+import React, {forwardRef, useRef, useState} from "react";
 import { experimental_VGrid as VGrid, VGridHandle } from "../../../src";
+import {CustomCellComponent} from "../../../lib";
 
 export default {
   component: VGrid,
@@ -47,6 +48,59 @@ export const Fixed: StoryObj = {
     );
   },
 };
+
+export const FitToViewport: StoryObj = {
+  render: () => {
+    return (
+      <VGrid style={{ height: "100vh" }} row={50} col={3}>
+        {({ rowIndex, colIndex }) => (
+          <div
+            style={{
+              border: "solid 1px gray",
+              background: "white",
+              padding: 4,
+              width: '33vw',
+            }}
+          >
+            {rowIndex} / {colIndex}
+          </div>
+        )}
+      </VGrid>
+    );
+  },
+};
+
+const Item: CustomCellComponent = forwardRef(({style: {minWidth: _minWidthUnused, minHeight: _minHeightUnused, ...style}, ...props}, ref) => {
+    return <div {...props} style={style} ref={ref} />
+})
+
+export const FitToViewportAdjusted: StoryObj = {
+  render: () => {
+    return (
+      <VGrid
+          style={{ height: "100vh" }}
+          row={50}
+          col={3}
+          item={Item}
+      >
+        {({ rowIndex, colIndex }) => (
+          <div
+            style={{
+              border: "solid 1px gray",
+              background: "white",
+              padding: 4,
+              width: '33vw',
+            }}
+          >
+            {rowIndex} / {colIndex}
+          </div>
+        )}
+      </VGrid>
+    );
+  },
+};
+
+
 
 export const DynamicHeight: StoryObj = {
   render: () => {


### PR DESCRIPTION
hi, I've investigated this issue https://github.com/inokawa/virtua/issues/634

The problem is :
 1) When mobile device is rotated, the callbacks for cell items in `createGridResizer` receive old values for sizes ( width and height, they're equal with previous, so we don't update anything ).
     But the callback for `viewportElement` receives actual value 
2) You can reproduce the issue with `FitToViewport` story ( just chose mobile device in storybook header and rotate twice )
3) The `minWidth` and `minHeight` css properties seems to break the thing , removing them fixes the issue ( `FitToViewportAdjusted` story)

I'm not sure it's ok to remove those properties as it might break in some cases .. I'll look deeper later, but maybe someone has idea 
