### PR TITLE
add more methods to VGridHandle

### DIFF
--- a/src/react/VGrid.tsx
+++ b/src/react/VGrid.tsx
@@ -137,12 +137,14 @@ export interface VGridHandle {
   findEndIndex: () => [x: number, y: number];
   /**
    * Get item offset from start.
-   * @param index index of item
+   * @param indexX horizontal index of item
+   * @param indexY vertical of item
    */
   getItemOffset(indexX: number, indexY: number): [x: number, y: number];
   /**
    * Get item size.
-   * @param index index of item
+   * @param indexX horizontal index of item
+   * @param indexY vertical of item
    */
   getItemSize(indexX: number, indexY: number): [width: number, height: number];
   /**

--- a/src/react/VGrid.tsx
+++ b/src/react/VGrid.tsx
@@ -128,6 +128,24 @@ export interface VGridHandle {
    */
   readonly viewportWidth: number;
   /**
+   * Find the start index of visible range of items.
+   */
+  findStartIndex: () => [x: number, y: number];
+  /**
+   * Find the end index of visible range of items.
+   */
+  findEndIndex: () => [x: number, y: number];
+  /**
+   * Get item offset from start.
+   * @param index index of item
+   */
+  getItemOffset(indexX: number, indexY: number): [x: number, y: number];
+  /**
+   * Get item size.
+   * @param index index of item
+   */
+  getItemSize(indexX: number, indexY: number): [width: number, height: number];
+  /**
    * Scroll to the item specified by index.
    * @param indexX horizontal index of item
    * @param indexY vertical index of item
@@ -347,6 +365,10 @@ export const VGrid = forwardRef<VGridHandle, VGridProps>(
         get viewportWidth() {
           return hStore.$getViewportSize();
         },
+        findStartIndex: () => [hStore.$findStartIndex(), vStore.$findStartIndex()],
+        findEndIndex: () => [hStore.$findEndIndex(), vStore.$findEndIndex()],
+        getItemOffset: (indexX, indexY) => [hStore.$getItemOffset(indexX), vStore.$getItemOffset(indexY)],
+        getItemSize: (indexX, indexY) => [hStore.$getItemSize(indexX), vStore.$getItemSize(indexY)],
         scrollToIndex: scroller.$scrollToIndex,
         scrollTo: scroller.$scrollTo,
         scrollBy: scroller.$scrollBy,


### PR DESCRIPTION
fixes #658

seems that there is no vue/solid/svelte equivalent for VGrid and no tests for these ref methods, so all that's really needed is just to add them.