### PR TITLE
SolidJS: move ACTION_ITEMS_LENGTH_CHANGE to dataSlice memo

### DIFF
--- a/src/solid/Virtualizer.tsx
+++ b/src/solid/Virtualizer.tsx
@@ -271,9 +271,11 @@ export const Virtualizer = <T,>(props: VirtualizerProps<T>): JSX.Element => {
 
   const dataSlice = createMemo<T[]>(() => {
     const count = props.data.length;
-    if (count !== store.$getItemsLength()) {
-      store.$update(ACTION_ITEMS_LENGTH_CHANGE, [count, untrack(() => props.shift)]);
-    }
+    untrack(() => {
+      if (count !== store.$getItemsLength()) {
+        store.$update(ACTION_ITEMS_LENGTH_CHANGE, [count, props.shift]);
+      }
+    });
     const [start, end] = range();
     return end >= 0 ? props.data.slice(start, end + 1) : [];
   });

--- a/src/solid/Virtualizer.tsx
+++ b/src/solid/Virtualizer.tsx
@@ -254,17 +254,6 @@ export const Virtualizer = <T,>(props: VirtualizerProps<T>): JSX.Element => {
 
   createComputed(
     on(
-      () => props.data.length,
-      (count) => {
-        if (count !== store.$getItemsLength()) {
-          store.$update(ACTION_ITEMS_LENGTH_CHANGE, [count, props.shift]);
-        }
-      }
-    )
-  );
-
-  createComputed(
-    on(
       () => props.startMargin || 0,
       (value) => {
         if (value !== store.$getStartSpacerSize()) {
@@ -281,6 +270,10 @@ export const Virtualizer = <T,>(props: VirtualizerProps<T>): JSX.Element => {
   );
 
   const dataSlice = createMemo<T[]>(() => {
+    const count = props.data.length;
+    if (count !== store.$getItemsLength()) {
+      store.$update(ACTION_ITEMS_LENGTH_CHANGE, [count, untrack(() => props.shift)]);
+    }
     const [start, end] = range();
     return end >= 0 ? props.data.slice(start, end + 1) : [];
   });

--- a/src/solid/WindowVirtualizer.tsx
+++ b/src/solid/WindowVirtualizer.tsx
@@ -10,7 +10,6 @@ import {
   JSX,
   Accessor,
   on,
-  createComputed,
   For,
   untrack,
 } from "solid-js";
@@ -192,17 +191,6 @@ export const WindowVirtualizer = <T,>(
     });
   });
 
-  createComputed(
-    on(
-      () => props.data.length,
-      (len) => {
-        if (len !== store.$getItemsLength()) {
-          store.$update(ACTION_ITEMS_LENGTH_CHANGE, [len, props.shift]);
-        }
-      }
-    )
-  );
-
   createEffect(
     on(stateVersion, () => {
       scroller.$fixScrollJump();
@@ -210,6 +198,12 @@ export const WindowVirtualizer = <T,>(
   );
 
   const dataSlice = createMemo<T[]>(() => {
+    const count = props.data.length;
+    untrack(() => {
+      if (count !== store.$getItemsLength()) {
+        store.$update(ACTION_ITEMS_LENGTH_CHANGE, [count, props.shift]);
+      }
+    });
     const [start, end] = range();
     return end >= 0 ? props.data.slice(start, end + 1) : [];
   });


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/46be3a28-ffe8-4680-bb99-95baca12e1e3)

Prevents a race condition (when shift=true + prepend) when `dataSlice()` is called before `ACTION_ITEMS_LENGTH_CHANGE` is called, but with an updated list.

This leads to unnecessary renderings, because a new list with an old range() results in an incorrect list, which does not contain items from the current viewport.