### PR TITLE
add Virtualizer domRef prop

### DIFF
--- a/src/react/Virtualizer.tsx
+++ b/src/react/Virtualizer.tsx
@@ -7,8 +7,6 @@ import {
   useRef,
   RefObject,
   useReducer,
-  useCallback,
-  MutableRefObject,
   Ref,
 } from "react";
 import {
@@ -34,6 +32,7 @@ import { ListItem } from "./ListItem";
 import { flushSync } from "react-dom";
 import { useChildren } from "./useChildren";
 import { CustomContainerComponent, CustomItemComponent } from "./types";
+import { useMergeRefs } from "./useMergeRefs";
 
 /**
  * Methods of {@link Virtualizer}.
@@ -106,7 +105,7 @@ export interface VirtualizerProps {
    */
   count?: number;
   /** Reference to the rendered DOM element. */
-  domRef?: Ref<HTMLDivElement | null>;
+  domRef?: Ref<HTMLDivElement>;
   /**
    * Number of items to render above/below the visible bounds of the list. Lower value will give better performance but you can increase to avoid showing blank items in fast scrolling.
    * @defaultValue 4
@@ -353,14 +352,9 @@ export const Virtualizer = forwardRef<VirtualizerHandle, VirtualizerProps>(
       items.push(...endItems);
     }
 
-    const elementRef = useCallback((el: HTMLDivElement | null) => {
-      updateRef(domRef, el)
-      updateRef(containerRef, el)
-    }, [domRef, containerRef]);
-
     return (
       <Element
-        ref={elementRef}
+        ref={useMergeRefs(containerRef, domRef)}
         style={{
           // contain: "content",
           overflowAnchor: "none", // opt out browser's scroll anchoring because it will conflict to scroll anchoring of virtualizer
@@ -377,11 +371,3 @@ export const Virtualizer = forwardRef<VirtualizerHandle, VirtualizerProps>(
     );
   }
 );
-
-function updateRef<T>(ref: Ref<T> | undefined, instance: null | T): void {
-  if (typeof ref === "function") {
-    ref(instance);
-  } else if (ref) {
-    (ref as MutableRefObject<T | null>).current = instance
-  }
-}

--- a/src/react/useMergeRefs.ts
+++ b/src/react/useMergeRefs.ts
@@ -1,0 +1,17 @@
+import { Ref, MutableRefObject, useCallback } from "react";
+
+export function useMergeRefs<T>(...refs: Array<Ref<T> | undefined>): Ref<T> {
+  return useCallback((instance: T | null) => {
+    for (const ref of refs) {
+      ref && updateRef(ref, instance);
+    }
+  }, refs);
+}
+
+function updateRef<T>(ref: Ref<T>, instance: T | null): void {
+  if (typeof ref === "function") {
+    ref(instance);
+  } else if (ref) {
+    (ref as MutableRefObject<T | null>).current = instance;
+  }
+}


### PR DESCRIPTION
fixes #659 

- add several props to access underlying DOM elements:
  1. `Virtualizer domRef`
  2. `VGrid domRef`
  3. `VGrid innerDomRef`
- add `useMergeRefs` utility hook to support this. copied core from [compose-react-refs](https://github.com/seznam/compose-react-refs/blob/master/composeRefs.ts#L41-L47) with light hook wrapper.
- I find this necessary for many of the advanced behaviors that I'm trying to implement.
- I am open to alternate names for these props, just went with `domRef` as it seemed to explicitly capture the intent of the prop.