### PR TITLE
feat(svelte): observe Virtualizer scrollRef prop using $effect

### DIFF
--- a/src/core/resizer.ts
+++ b/src/core/resizer.ts
@@ -37,6 +37,7 @@ export type ItemResizeObserver = (el: HTMLElement, i: number) => () => void;
 interface ListResizer {
   $observeRoot(viewportElement: HTMLElement): void;
   $observeItem: ItemResizeObserver;
+  $unobserveRoot(): void;
   $dispose(): void;
 }
 
@@ -83,6 +84,10 @@ export const createResizer = (
         mountedIndexes.delete(el);
         resizeObserver._unobserve(el);
       };
+    },
+    $unobserveRoot() {
+      viewportElement && resizeObserver._unobserve(viewportElement);
+      viewportElement = undefined;
     },
     $dispose: resizeObserver._dispose,
   };

--- a/src/core/scroller.ts
+++ b/src/core/scroller.ts
@@ -181,6 +181,7 @@ type ScrollObserver = ReturnType<typeof createScrollObserver>;
  */
 export type Scroller = {
   $observe: (viewportElement: HTMLElement) => void;
+  $unobserve: () => void;
   $dispose(): void;
   $scrollTo: (offset: number) => void;
   $scrollBy: (offset: number) => void;
@@ -322,6 +323,12 @@ export const createScroller = (
           }
         }
       );
+    },
+    $unobserve() {
+      viewportElement = undefined;
+
+      scrollObserver && scrollObserver._dispose();
+      scrollObserver = undefined;
     },
     $dispose() {
       scrollObserver && scrollObserver._dispose();

--- a/src/svelte/Virtualizer.svelte
+++ b/src/svelte/Virtualizer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" generics="T">
-  import { onMount, onDestroy } from "svelte";
+  import { onDestroy } from "svelte";
   import {
     ACTION_ITEMS_LENGTH_CHANGE,
     ACTION_START_OFFSET_CHANGE,
@@ -65,11 +65,13 @@
   let isScrolling = $derived(stateVersion && store.$isScrolling());
   let totalSize = $derived(stateVersion && store.$getTotalSize());
 
-  onMount(() => {
+  $effect(() => {
     const assignRef = (scrollable: HTMLElement) => {
+      resizer.$unobserveRoot();
       resizer.$observeRoot(scrollable);
+      scroller.$unobserve();
       scroller.$observe(scrollable);
-    };
+    }
     if (scrollRef) {
       assignRef(scrollRef);
     } else {


### PR DESCRIPTION
Fixes #690 

Changes
`ListResizer`: added `$unobserveRoot` which calls resizeObserver.unobserve and resets viewportElement variable.
`Scroller`: added `$unobserve` which calls scrollObserver._dispose and resets viewportElement, scrollObserver variable.
`Virtualizer`: onMount -> $effect

Should we use explicit unobserve calls or auto unobserve on multiple observe calls?