### PR TITLE
feat(react): VGrid supports resizing rows/cols

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -3,7 +3,7 @@
     "name": "Total",
     "path": "lib/index.mjs",
     "import": "*",
-    "limit": "5.5 kB"
+    "limit": "5.6 kB"
   },
   {
     "name": "VList",

--- a/src/core/resizer.ts
+++ b/src/core/resizer.ts
@@ -268,18 +268,20 @@ export const createGridResizer = (
         resizeObserver._unobserve(el);
       };
     },
-    $resize(rows: ItemResize[], cols: ItemResize[]) {
-      // treat empty array as "all" instead of Infinity
-      const minRow = rows.length > 0 ? Math.min(...rows.map(([i]) => i)) : 0;
-      const minCol = cols.length > 0 ? Math.min(...cols.map(([i]) => i)) : 0;
-      // delete the cache for all cells after (rowIndex, colIndex)
-      for (let r = minRow; r < vStore.$getItemsLength(); r++) {
-        for (let c = minCol; c < hStore.$getItemsLength(); c++) {
+    $resizeCols(cols: ItemResize[]) {
+      for (const [c] of cols) {
+        for (let r = 0; r < vStore.$getItemsLength(); r++) {
           sizeCache.delete(getKey(r, c));
         }
       }
-
       hStore.$update(ACTION_ITEM_RESIZE, cols);
+    },
+    $resizeRows(rows: ItemResize[]) {
+      for (const [r] of rows) {
+        for (let c = 0; c < hStore.$getItemsLength(); c++) {
+          sizeCache.delete(getKey(r, c));
+        }
+      }
       vStore.$update(ACTION_ITEM_RESIZE, rows);
     },
     $dispose: resizeObserver._dispose,

--- a/src/core/resizer.ts
+++ b/src/core/resizer.ts
@@ -268,13 +268,19 @@ export const createGridResizer = (
         resizeObserver._unobserve(el);
       };
     },
-    $resetAfter(rowIndex: number, colIndex: number) {
+    $resize(rows: ItemResize[], cols: ItemResize[]) {
+      // treat empty array as "all" instead of Infinity
+      const minRow = rows.length > 0 ? Math.min(...rows.map(([i]) => i)) : 0;
+      const minCol = cols.length > 0 ? Math.min(...cols.map(([i]) => i)) : 0;
       // delete the cache for all cells after (rowIndex, colIndex)
-      for (let r = rowIndex; r < vStore.$getItemsLength(); r++) {
-        for (let c = colIndex; c < hStore.$getItemsLength(); c++) {
+      for (let r = minRow; r < vStore.$getItemsLength(); r++) {
+        for (let c = minCol; c < hStore.$getItemsLength(); c++) {
           sizeCache.delete(getKey(r, c));
         }
       }
+
+      hStore.$update(ACTION_ITEM_RESIZE, cols);
+      vStore.$update(ACTION_ITEM_RESIZE, rows);
     },
     $dispose: resizeObserver._dispose,
   };

--- a/src/core/resizer.ts
+++ b/src/core/resizer.ts
@@ -268,6 +268,14 @@ export const createGridResizer = (
         resizeObserver._unobserve(el);
       };
     },
+    $resetAfter(rowIndex: number, colIndex: number) {
+      // delete the cache for all cells after (rowIndex, colIndex)
+      for (let r = rowIndex; r < vStore.$getItemsLength(); r++) {
+        for (let c = colIndex; c < hStore.$getItemsLength(); c++) {
+          sizeCache.delete(getKey(r, c));
+        }
+      }
+    },
     $dispose: resizeObserver._dispose,
   };
 };

--- a/src/react/VGrid.tsx
+++ b/src/react/VGrid.tsx
@@ -152,11 +152,16 @@ export interface VGridHandle {
    */
   getItemSize(indexX: number, indexY: number): [width: number, height: number];
   /**
-   * Resize individual columns and rows.
+   * Resize individual columns.
    * @param cols array of `[index, size]` to update column sizes
    * @param rows array of `[index, size]` to update row sizes
    */
-  resize(cols: VGridItemResize[], rows: VGridItemResize[]): void;
+  resizeCols(cols: VGridItemResize[]): void;
+  /**
+   * Resize individual rows.
+   * @param rows array of `[index, size]` to update row sizes
+   */
+  resizeRows(rows: VGridItemResize[]): void;
   /**
    * Scroll to the item specified by index.
    * @param indexX horizontal index of item
@@ -401,8 +406,11 @@ export const VGrid = forwardRef<VGridHandle, VGridProps>(
             hStore.$getItemSize(indexX),
             vStore.$getItemSize(indexY),
           ],
-          resize(cols, rows) {
-            resizer.$resize(rows, cols);
+          resizeCols(cols) {
+            resizer.$resizeCols(cols);
+          },
+          resizeRows(rows) {
+            resizer.$resizeRows(rows);
           },
           scrollToIndex: scroller.$scrollToIndex,
           scrollTo: scroller.$scrollTo,

--- a/src/react/VGrid.tsx
+++ b/src/react/VGrid.tsx
@@ -1,4 +1,4 @@
-import {
+import React, {
   JSX,
   memo,
   useRef,
@@ -30,8 +30,6 @@ import { ViewportComponentAttributes } from "./types";
 import { useLatestRef } from "./useLatestRef";
 import { flushSync } from "react-dom";
 import { useMergeRefs } from "./useMergeRefs";
-import { ACTION_ITEM_RESIZE } from "../core/store";
-import { ItemResize } from "../core/types";
 
 const genKey = (i: number, j: number) => `${i}-${j}`;
 
@@ -156,7 +154,10 @@ export interface VGridHandle {
    * @param cols array of `[index, size]` to update column sizes
    * @param rows array of `[index, size]` to update row sizes
    */
-  resize(cols: ItemResize[], rows: ItemResize[]): void;
+  resize(
+    cols: (readonly [index: number, size: number])[],
+    rows: (readonly [index: number, size: number])[]
+  ): void;
   /**
    * Scroll to the item specified by index.
    * @param indexX horizontal index of item
@@ -402,12 +403,7 @@ export const VGrid = forwardRef<VGridHandle, VGridProps>(
             vStore.$getItemSize(indexY),
           ],
           resize(cols, rows) {
-            // treat empty array as "all" instead of Infinity
-            const minRow = rows.length > 0 ? Math.min(...rows.map(([i]) => i)) : 0;
-            const minCol = cols.length > 0 ? Math.min(...cols.map(([i]) => i)) : 0;
-            resizer.$resetAfter(minRow, minCol)
-            hStore.$update(ACTION_ITEM_RESIZE, cols);
-            vStore.$update(ACTION_ITEM_RESIZE, rows);
+            resizer.$resize(rows, cols);
           },
           scrollToIndex: scroller.$scrollToIndex,
           scrollTo: scroller.$scrollTo,

--- a/src/react/VGrid.tsx
+++ b/src/react/VGrid.tsx
@@ -154,7 +154,6 @@ export interface VGridHandle {
   /**
    * Resize individual columns.
    * @param cols array of `[index, size]` to update column sizes
-   * @param rows array of `[index, size]` to update row sizes
    */
   resizeCols(cols: VGridItemResize[]): void;
   /**

--- a/src/react/VGrid.tsx
+++ b/src/react/VGrid.tsx
@@ -402,7 +402,10 @@ export const VGrid = forwardRef<VGridHandle, VGridProps>(
             vStore.$getItemSize(indexY),
           ],
           resize(cols, rows) {
-            resizer.$resetAfter(Math.min(...rows.map(([i]) => i)), Math.min(...cols.map(([i]) => i)))
+            // treat empty array as "all" instead of Infinity
+            const minRow = rows.length > 0 ? Math.min(...rows.map(([i]) => i)) : 0;
+            const minCol = cols.length > 0 ? Math.min(...cols.map(([i]) => i)) : 0;
+            resizer.$resetAfter(minRow, minCol)
             hStore.$update(ACTION_ITEM_RESIZE, cols);
             vStore.$update(ACTION_ITEM_RESIZE, rows);
           },

--- a/src/react/VGrid.tsx
+++ b/src/react/VGrid.tsx
@@ -101,6 +101,8 @@ const Cell = memo(
   }
 );
 
+export type VGridItemResize = readonly [index: number, size: number];
+
 /**
  * Methods of {@link VGrid}.
  */
@@ -154,10 +156,7 @@ export interface VGridHandle {
    * @param cols array of `[index, size]` to update column sizes
    * @param rows array of `[index, size]` to update row sizes
    */
-  resize(
-    cols: (readonly [index: number, size: number])[],
-    rows: (readonly [index: number, size: number])[]
-  ): void;
+  resize(cols: VGridItemResize[], rows: VGridItemResize[]): void;
   /**
    * Scroll to the item specified by index.
    * @param indexX horizontal index of item

--- a/src/react/VGrid.tsx
+++ b/src/react/VGrid.tsx
@@ -30,6 +30,8 @@ import { ViewportComponentAttributes } from "./types";
 import { useLatestRef } from "./useLatestRef";
 import { flushSync } from "react-dom";
 import { useMergeRefs } from "./useMergeRefs";
+import { ACTION_ITEM_RESIZE } from "../core/store";
+import { ItemResize } from "../core/types";
 
 const genKey = (i: number, j: number) => `${i}-${j}`;
 
@@ -149,6 +151,12 @@ export interface VGridHandle {
    * @param indexY vertical of item
    */
   getItemSize(indexX: number, indexY: number): [width: number, height: number];
+  /**
+   * Resize individual columns and rows.
+   * @param cols array of `[index, size]` to update column sizes
+   * @param rows array of `[index, size]` to update row sizes
+   */
+  resize(cols: ItemResize[], rows: ItemResize[]): void;
   /**
    * Scroll to the item specified by index.
    * @param indexX horizontal index of item
@@ -393,6 +401,11 @@ export const VGrid = forwardRef<VGridHandle, VGridProps>(
             hStore.$getItemSize(indexX),
             vStore.$getItemSize(indexY),
           ],
+          resize(cols, rows) {
+            resizer.$resetAfter(Math.min(...rows.map(([i]) => i)), Math.min(...cols.map(([i]) => i)))
+            hStore.$update(ACTION_ITEM_RESIZE, cols);
+            vStore.$update(ACTION_ITEM_RESIZE, rows);
+          },
           scrollToIndex: scroller.$scrollToIndex,
           scrollTo: scroller.$scrollTo,
           scrollBy: scroller.$scrollBy,

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -9,6 +9,7 @@ export type {
 } from "./WindowVirtualizer";
 export { VGrid as experimental_VGrid } from "./VGrid";
 export type {
+  VGridItemResize,
   VGridProps,
   VGridHandle,
   CustomCellComponent,

--- a/stories/react/basics/VGrid.stories.tsx
+++ b/stories/react/basics/VGrid.stories.tsx
@@ -102,49 +102,89 @@ export const DynamicWidth: StoryObj = {
   },
 };
 
-
 export const Resizeable: StoryObj = {
   render: () => {
-    const LENGTH = 1000;
-    const [width, setWidth] = useState(80)
-    const [height, setHeight] = useState(80)
+    const SIZE = 80;
+    const LENGTH = 100;
+    const [widths, setWidths] = useState(() => new Map<number, number>());
+    const [heights, setHeights] = useState(() => new Map<number, number>());
     const grid = useRef<VGridHandle>(null);
+
+    function randomize() {
+      const indexes: number[] = [];
+      const newWidths = new Map<number, number>();
+      const newHeights = new Map<number, number>();
+      for (let i = 1; i < LENGTH; i++) {
+        indexes.push(i);
+        if (Math.random() < 0.8) {
+          const w = 40 + Math.round(200 * Math.random());
+          newWidths.set(i, w);
+        }
+        if (Math.random() < 0.8) {
+          const h = 40 + Math.round(200 * Math.random());
+          newHeights.set(i, h);
+        }
+      }
+      grid.current?.resize(
+        indexes.map((i) => [i, newWidths.get(i) ?? SIZE]),
+        indexes.map((i) => [i, newHeights.get(i) ?? SIZE])
+      );
+      setWidths(newWidths);
+      setHeights(newHeights);
+    }
+
     return (
       <div style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
-        <div>
-          <label>
-            col
-            <input
-              type="number"
-              value={width}
-              onChange={(e) => {
-                setWidth(e.target.valueAsNumber);
-              }}
-            />
-          </label>
-          <label>
-            row
-            <input
-              type="number"
-              value={height}
-              onChange={(e) => {
-                setHeight(e.target.valueAsNumber);
-              }}
-            />
-          </label>
-        </div>
-        <VGrid ref={grid} style={{ height: "100vh" }} row={LENGTH} col={LENGTH} cellHeight={height} cellWidth={width}>
+        <VGrid
+          ref={grid}
+          style={{ height: "100vh" }}
+          row={LENGTH}
+          col={LENGTH}
+          cellHeight={SIZE}
+          cellWidth={SIZE}
+        >
           {({ rowIndex, colIndex }) => (
             <div
               style={{
                 border: "solid 1px gray",
                 background: "white",
                 padding: 4,
-                width,
-                height,
+                width: widths.get(colIndex) ?? SIZE,
+                height: heights.get(rowIndex) ?? SIZE,
               }}
             >
-              {rowIndex} / {colIndex}
+              <div>
+                {rowIndex} / {colIndex}
+              </div>
+              {rowIndex === 0 && colIndex > 0 && (
+                // resize column
+                <input
+                  style={{ width: 50 }}
+                  type="number"
+                  value={widths.get(colIndex) ?? SIZE}
+                  onChange={(e) => {
+                    const w = e.target.valueAsNumber;
+                    grid.current?.resize([[colIndex, w]], []);
+                    setWidths((map) => new Map(map).set(colIndex, w));
+                  }}
+                />
+              )}
+              {colIndex === 0 && rowIndex > 0 && (
+                // resize row
+                <input
+                  style={{ width: 50 }}
+                  type="number"
+                  value={heights.get(rowIndex) ?? SIZE}
+                  onChange={(e) => {
+                    const h = e.target.valueAsNumber;
+                    grid.current?.resize([], [[rowIndex, h]]);
+                    setHeights((map) => new Map(map).set(rowIndex, h));
+                  }}
+                />
+              )}
+              {colIndex === 0 && rowIndex === 0 && (
+                <button onClick={randomize}>random</button>
+              )}
             </div>
           )}
         </VGrid>
@@ -152,7 +192,6 @@ export const Resizeable: StoryObj = {
     );
   },
 };
-
 
 export const ScrollTo: StoryObj = {
   render: () => {

--- a/stories/react/basics/VGrid.stories.tsx
+++ b/stories/react/basics/VGrid.stories.tsx
@@ -111,84 +111,75 @@ export const Resizeable: StoryObj = {
     const grid = useRef<VGridHandle>(null);
 
     function randomize() {
-      const indexes: number[] = [];
+      const getSize = () => Math.random() < 0.8 ? 40 + Math.round(200 * Math.random()) : SIZE;
       const newWidths = new Map<number, number>();
       const newHeights = new Map<number, number>();
+      // skip index 0 to keep inputs stable
       for (let i = 1; i < LENGTH; i++) {
-        indexes.push(i);
-        if (Math.random() < 0.8) {
-          const w = 40 + Math.round(200 * Math.random());
-          newWidths.set(i, w);
-        }
-        if (Math.random() < 0.8) {
-          const h = 40 + Math.round(200 * Math.random());
-          newHeights.set(i, h);
-        }
+        newWidths.set(i, getSize());
+        newHeights.set(i, getSize());
       }
-      grid.current?.resize(
-        indexes.map((i) => [i, newWidths.get(i) ?? SIZE]),
-        indexes.map((i) => [i, newHeights.get(i) ?? SIZE])
-      );
+      grid.current?.resize([...newWidths.entries()], [...newHeights.entries()]);
       setWidths(newWidths);
       setHeights(newHeights);
     }
 
     return (
-      <div style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
-        <VGrid
-          ref={grid}
-          style={{ height: "100vh" }}
-          row={LENGTH}
-          col={LENGTH}
-          cellHeight={SIZE}
-          cellWidth={SIZE}
-        >
-          {({ rowIndex, colIndex }) => (
-            <div
-              style={{
-                border: "solid 1px gray",
-                background: "white",
-                padding: 4,
-                width: widths.get(colIndex) ?? SIZE,
-                height: heights.get(rowIndex) ?? SIZE,
-              }}
-            >
-              <div>
-                {rowIndex} / {colIndex}
-              </div>
-              {rowIndex === 0 && colIndex > 0 && (
-                // resize column
-                <input
-                  style={{ width: 50 }}
-                  type="number"
-                  value={widths.get(colIndex) ?? SIZE}
-                  onChange={(e) => {
-                    const w = e.target.valueAsNumber;
-                    grid.current?.resize([[colIndex, w]], []);
-                    setWidths((map) => new Map(map).set(colIndex, w));
-                  }}
-                />
-              )}
-              {colIndex === 0 && rowIndex > 0 && (
-                // resize row
-                <input
-                  style={{ width: 50 }}
-                  type="number"
-                  value={heights.get(rowIndex) ?? SIZE}
-                  onChange={(e) => {
-                    const h = e.target.valueAsNumber;
-                    grid.current?.resize([], [[rowIndex, h]]);
-                    setHeights((map) => new Map(map).set(rowIndex, h));
-                  }}
-                />
-              )}
-              {colIndex === 0 && rowIndex === 0 && (
-                <button onClick={randomize}>random</button>
-              )}
+      <VGrid
+        ref={grid}
+        style={{ height: "100vh" }}
+        row={LENGTH}
+        col={LENGTH}
+        cellHeight={SIZE}
+        cellWidth={SIZE}
+      >
+        {({ rowIndex, colIndex }) => (
+          <div
+            style={{
+              border: "solid 1px gray",
+              background: "white",
+              padding: 4,
+              width: widths.get(colIndex) ?? SIZE,
+              height: heights.get(rowIndex) ?? SIZE,
+            }}
+          >
+            <div>
+              {rowIndex} / {colIndex}
             </div>
-          )}
-        </VGrid>
-      </div>
+
+            {colIndex === 0 && rowIndex === 0 ? (
+              // randomize all cols & rows
+              <button onClick={randomize}>random</button>
+            ) : rowIndex === 0 ? (
+              // resize column
+              <input
+                type="number"
+                step={5}
+                value={widths.get(colIndex) ?? SIZE}
+                style={{ width: 50 }}
+                onChange={(e) => {
+                  const w = e.target.valueAsNumber;
+                  grid.current?.resize([[colIndex, w]], []);
+                  setWidths((map) => new Map(map).set(colIndex, w));
+                }}
+              />
+            ) : colIndex === 0 ? (
+              // resize row
+              <input
+                type="number"
+                step={5}
+                value={heights.get(rowIndex) ?? SIZE}
+                style={{ width: 50 }}
+                onChange={(e) => {
+                  const h = e.target.valueAsNumber;
+                  grid.current?.resize([], [[rowIndex, h]]);
+                  setHeights((map) => new Map(map).set(rowIndex, h));
+                }}
+              />
+            ) : null}
+          </div>
+        )}
+      </VGrid>
     );
   },
 };

--- a/stories/react/basics/VGrid.stories.tsx
+++ b/stories/react/basics/VGrid.stories.tsx
@@ -102,6 +102,58 @@ export const DynamicWidth: StoryObj = {
   },
 };
 
+
+export const Resizeable: StoryObj = {
+  render: () => {
+    const LENGTH = 1000;
+    const [width, setWidth] = useState(80)
+    const [height, setHeight] = useState(80)
+    const grid = useRef<VGridHandle>(null);
+    return (
+      <div style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
+        <div>
+          <label>
+            col
+            <input
+              type="number"
+              value={width}
+              onChange={(e) => {
+                setWidth(e.target.valueAsNumber);
+              }}
+            />
+          </label>
+          <label>
+            row
+            <input
+              type="number"
+              value={height}
+              onChange={(e) => {
+                setHeight(e.target.valueAsNumber);
+              }}
+            />
+          </label>
+        </div>
+        <VGrid ref={grid} style={{ height: "100vh" }} row={LENGTH} col={LENGTH} cellHeight={height} cellWidth={width}>
+          {({ rowIndex, colIndex }) => (
+            <div
+              style={{
+                border: "solid 1px gray",
+                background: "white",
+                padding: 4,
+                width,
+                height,
+              }}
+            >
+              {rowIndex} / {colIndex}
+            </div>
+          )}
+        </VGrid>
+      </div>
+    );
+  },
+};
+
+
 export const ScrollTo: StoryObj = {
   render: () => {
     const LENGTH = 1000;

--- a/stories/react/basics/VGrid.stories.tsx
+++ b/stories/react/basics/VGrid.stories.tsx
@@ -119,7 +119,8 @@ export const Resizeable: StoryObj = {
         newWidths.set(i, getSize());
         newHeights.set(i, getSize());
       }
-      grid.current?.resize([...newWidths.entries()], [...newHeights.entries()]);
+      grid.current?.resizeCols([...newWidths.entries()])
+      grid.current?.resizeRows([...newHeights.entries()]);
       setWidths(newWidths);
       setHeights(newHeights);
     }
@@ -159,7 +160,7 @@ export const Resizeable: StoryObj = {
                 style={{ width: 50 }}
                 onChange={(e) => {
                   const w = e.target.valueAsNumber;
-                  grid.current?.resize([[colIndex, w]], []);
+                  grid.current?.resizeCols([[colIndex, w]]);
                   setWidths((map) => new Map(map).set(colIndex, w));
                 }}
               />
@@ -172,7 +173,7 @@ export const Resizeable: StoryObj = {
                 style={{ width: 50 }}
                 onChange={(e) => {
                   const h = e.target.valueAsNumber;
-                  grid.current?.resize([], [[rowIndex, h]]);
+                  grid.current?.resizeRows([[rowIndex, h]]);
                   setHeights((map) => new Map(map).set(rowIndex, h));
                 }}
               />


### PR DESCRIPTION
fixes #668 

- add `VGridHandle.resize(cols, rows)` method and `resizer.$resetAfter(row, col)` method to support it
- add a story that demonstrates resizing one row or column, or randomizing all of them
- open to feedback on the API here! I went through a bunch of iterations locally and this is the first that seemed to really work robustly in the ways I wanted it to.