### PR TITLE
Window Virtualizer Update: Proper svelte binds for `store` and `scroller` variables, along with Storybook Story to document functionality

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -13,6 +13,7 @@ export {
   createScroller,
   createWindowScroller,
   createGridScroller,
+	type WindowScroller
 } from "./scroller";
 export {
   createResizer,

--- a/src/svelte/WindowVirtualizer.svelte
+++ b/src/svelte/WindowVirtualizer.svelte
@@ -30,18 +30,15 @@
     children,
     onscroll,
     onscrollend,
+		store = $bindable(),
+		scroller = $bindable()
   }: Props = $props();
 
-  const store = createVirtualStore(
-    data.length,
-    itemSize,
-    overscan,
-    undefined,
-    undefined,
-    !itemSize
-  );
-  const resizer = createWindowResizer(store, horizontal);
-  const scroller = createWindowScroller(store, horizontal);
+	store = createVirtualStore(data.length, itemSize, overscan, undefined, undefined, !itemSize);
+	scroller = createWindowScroller(store, horizontal);
+	
+	const resizer = createWindowResizer(store, horizontal);
+  
   const unsubscribeStore = store.$subscribe(UPDATE_VIRTUAL_STATE, () => {
     stateVersion = store.$getStateVersion();
   });
@@ -69,6 +66,7 @@
     resizer.$observeRoot(containerRef!);
     scroller.$observe(containerRef!);
   });
+	
   onDestroy(() => {
     unsubscribeStore();
     unsubscribeOnScroll();

--- a/src/svelte/WindowVirtualizer.type.ts
+++ b/src/svelte/WindowVirtualizer.type.ts
@@ -1,69 +1,78 @@
 import { type Snippet } from "svelte";
-import { type ScrollToIndexOpts } from "../core";
+import { VirtualStore, type ScrollToIndexOpts } from "../core";
+import { WindowScroller } from '../core/scroller';
 
 /**
  * Props of {@link WindowVirtualizer}.
  */
 export interface WindowVirtualizerProps<T> {
-  /**
-   * The data items rendered by this component.
-   */
-  data: T[];
-  /**
-   * The elements renderer snippet.
-   */
-  children: Snippet<[item: T, index: number]>;
-  /**
-   * Function that returns the key of an item in the list. It's recommended to specify whenever possible for performance.
-   * @default defaultGetKey (returns index of item)
-   */
-  getKey?: (data: T, index: number) => string | number;
-  /**
-   * Number of items to render above/below the visible bounds of the list. You can increase to avoid showing blank items in fast scrolling.
-   * @defaultValue 4
-   */
-  overscan?: number;
-  /**
-   * Item size hint for unmeasured items. It will help to reduce scroll jump when items are measured if used properly.
-   *
-   * - If not set, initial item sizes will be automatically estimated from measured sizes. This is recommended for most cases.
-   * - If set, you can opt out estimation and use the value as initial item size.
-   */
-  itemSize?: number;
-  /**
-   * While true is set, scroll position will be maintained from the end not usual start when items are added to/removed from start. It's recommended to set false if you add to/remove from mid/end of the list because it can cause unexpected behavior. This prop is useful for reverse infinite scrolling.
-   */
-  shift?: boolean;
-  /**
-   * If true, rendered as a horizontally scrollable list. Otherwise rendered as a vertically scrollable list.
-   */
-  horizontal?: boolean;
-  /**
-   * Callback invoked whenever scroll offset changes.
-   */
-  onscroll?: () => void;
-  /**
-   * Callback invoked when scrolling stops.
-   */
-  onscrollend?: () => void;
+	/**
+	 * The data items rendered by this component.
+	 */
+	data: T[];
+	/**
+	 * The elements renderer snippet.
+	 */
+	children: Snippet<[item: T, index: number]>;
+	/**
+	 * Function that returns the key of an item in the list. It's recommended to specify whenever possible for performance.
+	 * @default defaultGetKey (returns index of item)
+	 */
+	getKey?: (data: T, index: number) => string | number;
+	/**
+	 * Number of items to render above/below the visible bounds of the list. You can increase to avoid showing blank items in fast scrolling.
+	 * @defaultValue 4
+	 */
+	overscan?: number;
+	/**
+	 * Item size hint for unmeasured items. It will help to reduce scroll jump when items are measured if used properly.
+	 *
+	 * - If not set, initial item sizes will be automatically estimated from measured sizes. This is recommended for most cases.
+	 * - If set, you can opt out estimation and use the value as initial item size.
+	 */
+	itemSize?: number;
+	/**
+	 * While true is set, scroll position will be maintained from the end not usual start when items are added to/removed from start. It's recommended to set false if you add to/remove from mid/end of the list because it can cause unexpected behavior. This prop is useful for reverse infinite scrolling.
+	 */
+	shift?: boolean;
+	/**
+	 * If true, rendered as a horizontally scrollable list. Otherwise rendered as a vertically scrollable list.
+	 */
+	horizontal?: boolean;
+	/**
+	 * Callback invoked whenever scroll offset changes.
+	 */
+	onscroll?: () => void;
+	/**
+	 * Callback invoked when scrolling stops.
+	 */
+	onscrollend?: () => void;
+	/**
+	 * Reference to the virtual store utilized by the virtualizer. You can use this prop to bind to the store instance & access it's methods.
+	 */
+	store?: VirtualStore;
+	/**
+	 * Reference to the scroller utilized by the virtualizer. You can use this prop to bind to the scroller instance & access it's methods.
+	 */
+	scroller?: WindowScroller;
 }
 
 /**
  * Methods of {@link WindowVirtualizer}.
  */
 export interface WindowVirtualizerHandle {
-  /**
-   * Find the start index of visible range of items.
-   */
-  findStartIndex: () => number;
-  /**
-   * Find the end index of visible range of items.
-   */
-  findEndIndex: () => number;
-  /**
-   * Scroll to the item specified by index.
-   * @param index index of item
-   * @param opts options
-   */
-  scrollToIndex(index: number, opts?: ScrollToIndexOpts): void;
+	/**
+	 * Find the start index of visible range of items.
+	 */
+	findStartIndex: () => number;
+	/**
+	 * Find the end index of visible range of items.
+	 */
+	findEndIndex: () => number;
+	/**
+	 * Scroll to the item specified by index.
+	 * @param index index of item
+	 * @param opts options
+	 */
+	scrollToIndex(index: number, opts?: ScrollToIndexOpts): void;
 }

--- a/stories/svelte/WindowVirtualizer.svelte
+++ b/stories/svelte/WindowVirtualizer.svelte
@@ -1,25 +1,31 @@
 <script lang="ts">
-  import { WindowVirtualizer } from "../../src/svelte";
+	import { WindowVirtualizer } from '../../src/svelte';
+	import { type VirtualStore } from '../../src/core';
 
-  const sizes = [20, 40, 180, 77];
+	const sizes = [20, 40, 180, 77];
 
-  const data = Array.from({ length: 1000 }).map((_, i) => sizes[i % 4]!);
+	const data = Array.from({ length: 1000 }).map((_, i) => sizes[i % 4]!);
 </script>
 
 <div style="padding: 200px 100px;">
-  <div style="border: solid 1px gray;">
-    <WindowVirtualizer {data} getKey={(_, i) => i}>
-      {#snippet children(item, index)}
-        <div
-          style="
+	<div style="border: solid 1px gray;">
+		<WindowVirtualizer {data} getKey={(_, i) => i}>
+			{#snippet children(item, index)}
+				<div
+					style="
+						padding: 10px;
+					  width: 100%;
+						display: flex;
+						align-items: center;
+						justify-content: space-between;
             height: {item}px;
             background: white;
             border-bottom: solid 1px #ccc;
           "
-        >
-          {index}
-        </div>
-      {/snippet}
-    </WindowVirtualizer>
-  </div>
+				>
+					{index}
+				</div>
+			{/snippet}
+		</WindowVirtualizer>
+	</div>
 </div>

--- a/stories/svelte/WindowVirtualizerWithBindings.stories.tsx
+++ b/stories/svelte/WindowVirtualizerWithBindings.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/svelte-vite";
+import { WindowVirtualizer } from "../../src/svelte";
+import DefaultComponent from "./WindowVirtualizerWithBindings.svelte";
+
+export default {
+  component: WindowVirtualizer,
+} satisfies Meta;
+
+export const Default: StoryObj = {
+  render: () => ({
+    Component: DefaultComponent,
+  }),
+};

--- a/stories/svelte/WindowVirtualizerWithBindings.svelte
+++ b/stories/svelte/WindowVirtualizerWithBindings.svelte
@@ -37,8 +37,10 @@
 	<input type="number" bind:value={index} min={0} />
 	<button
 		onclick={(e) => {
-			const itemSize = scroller?.$scrollToIndex(index);
-			console.log(itemSize);
+			scroller?.$scrollToIndex(index - 1, {
+				align: 'start',
+				smooth: true,
+			});
 		}}
 	>
 		Scroll to {index}

--- a/stories/svelte/WindowVirtualizerWithBindings.svelte
+++ b/stories/svelte/WindowVirtualizerWithBindings.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	import { WindowVirtualizer } from '../../src/svelte';
+	import { type VirtualStore, type WindowScroller } from '../../src/core';
+
+	const sizes = [20, 40, 180, 77];
+
+	const data = Array.from({ length: 1000 }).map((_, i) => sizes[i % 5]!);
+
+	let store: VirtualStore | undefined = $state();
+	let scroller: WindowScroller | undefined = $state();
+
+	let index: number = $state(0);
+</script>
+
+<div
+	style="display: flex; position: fixed; z-index: 500; font-family: sans-serif; left: 0px; right: 0px; top: 0px; padding: 10px; gap: 10px; background: white;"
+>
+	<button
+		onclick={(e) => {
+			const itemSize = store?.$getItemsLength();
+			alert(`Items count: ${itemSize}`);
+		}}
+	>
+		Get Items Count
+	</button>
+	<button
+		style="margin-right: auto;"
+		onclick={(e) => {
+			const cache = store?.$getCacheSnapshot();
+			console.log('Cache', cache);
+			alert('Cache printed to console');
+		}}
+	>
+		Print Cache to Console
+	</button>
+
+	<input type="number" bind:value={index} min={0} />
+	<button
+		onclick={(e) => {
+			const itemSize = scroller?.$scrollToIndex(index);
+			console.log(itemSize);
+		}}
+	>
+		Scroll to {index}
+	</button>
+</div>
+
+<div style="padding: 200px 100px;">
+	<div style="border: solid 1px gray;">
+		<WindowVirtualizer {data} getKey={(_, i) => i} bind:store bind:scroller>
+			{#snippet children(item, index)}
+				<div
+					style="
+						padding: 10px;
+						display: flex;
+						align-items: center;
+						justify-content: space-between;
+            height: {item}px;
+            background: white;
+            border-bottom: solid 1px #ccc;
+          "
+				>
+					{index}
+					<button
+						onclick={(e) => {
+							const itemSize = store?.$getItemSize(index);
+							alert(`Item size: ${itemSize}px`);
+						}}
+					>
+						Get Item Size
+					</button>
+				</div>
+			{/snippet}
+		</WindowVirtualizer>
+	</div>
+</div>


### PR DESCRIPTION
Key Changes:

- Updating Window Virtualizer to use $bindable for the `store` and `scroller` variables - meaning methods don't need to be exported separately & users have much more flexibility to interact with the API 
- Updated Storybook Stories to highlight new functionalities > View `WindowVirtualizerWithBindings` Story for more

Preview below:
<img width="1591" height="1307" alt="image" src="https://github.com/user-attachments/assets/0e8196e4-cef3-4d10-8ce3-b47a9467266e" />

---

Note:

This is only for the WindowVirtualizer, not the normal Virtualizer - however I am happy to apply the changes there as well if needed.