### PR TITLE
Potentially fixes #549 (Failed to execute observe on ResizeObserver)

### DIFF
--- a/src/react/Virtualizer.tsx
+++ b/src/react/Virtualizer.tsx
@@ -283,7 +283,7 @@ export const Virtualizer = forwardRef<VirtualizerHandle, VirtualizerProps>(
         resizer.$observeRoot(e);
         scroller.$observe(e);
       };
-      if (scrollRef) {
+      if (scrollRef && scrollRef[refKey]) {
         // parent's ref doesn't exist when useLayoutEffect is called
         microtask(() => assignScrollableElement(scrollRef[refKey]!));
       } else {


### PR DESCRIPTION
Potentially fixes #549, which causes the code to throw the error `Failed to execute 'observe' on 'ResizeObserver': parameter 1 is not of type 'Element'` and generally freezes the browser (app crashes or is unusable). Reproducing this is tricky, but the essence of the issue is a race condition where the parent element is mounted and unmounted quickly. In order for the issue to occur, the `reverse` prop needs to be set on the `VList`.

It seems that when the `reverse` prop is set, the `Virtualizer` expects `scrollRef` to be set (`scrollRef={shouldReverse ? scrollRef : undefined}`) and on quick unmounts/mounts the reference is lost, but the `microtask` function inside the `Virtualizer` still moves forward as if the reference exists.

It's unclear to me if this is the ideal way to go about the issue, but it's the only way that I've found so far.