### PR TITLE
fix(svelte): filter stale indices in Virtualizer to prevent undefined data access

### DIFF
--- a/src/svelte/Virtualizer.svelte
+++ b/src/svelte/Virtualizer.svelte
@@ -70,8 +70,10 @@
   let negative = $derived(stateVersion && scroller.$isNegative());
 
   let indexes = $derived.by(() => {
+    // https://github.com/inokawa/virtua/pull/847
+    const len = data.length;
+
     const [start, end] = range;
-    const len = data.length; // dependency on data.length for filtering
     const arr: number[] = [];
     if (keepMounted) {
       const mounted = new Set(keepMounted);
@@ -79,20 +81,19 @@
         mounted.add(i);
       }
       for (const index of sort([...mounted])) {
-        if (index >= 0 && index < len) {
+        if (index < len) {
           arr.push(index);
         }
       }
     } else {
       for (let i = start; i <= end; i++) {
-        if (i >= 0 && i < len) {
+        if (i < len) {
           arr.push(i);
         }
       }
     }
     return arr;
   });
-
 
   onMount(() => {
     const container = containerRef!;

--- a/src/svelte/WindowVirtualizer.svelte
+++ b/src/svelte/WindowVirtualizer.svelte
@@ -63,10 +63,15 @@
   let negative = $derived(stateVersion && scroller.$isNegative());
 
   let indexes = $derived.by(() => {
+    // https://github.com/inokawa/virtua/pull/847
+    const len = data.length;
+
     const [start, end] = range;
     const arr: number[] = [];
     for (let i = start; i <= end; i++) {
-      arr.push(i);
+      if (i < len) {
+        arr.push(i);
+      }
     }
     return arr;
   });


### PR DESCRIPTION
fix #851 

## Summary
  - Add `data.length` dependency to `indexes` derived to ensure recalculation when data changes
  - Filter indices to valid range (`index >= 0 && index < len`) to prevent stale indices

  ## Problem
  During reactive updates (e.g., delete operations), the `indexes` derived could contain stale indices that exceed the current `data.length`, causing "Cannot
  read properties of undefined" errors when accessing `data[index]` in the `#each` block.

  ## Solution
  By accessing `data.length` in the `indexes` derived, we create a reactive dependency that ensures `indexes` recalculates atomically with data changes. The
  filtering ensures only valid indices are included.

  ## Test plan
  - Create structural changes (e.g. delete) in items of a virtualized list with Svelte 5
  - Verify no runtime exceptions occur