### PR TITLE
fix: extend scroll jump deferral and repaint hack to desktop Safari

### DIFF
--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -40,6 +40,17 @@ export const isIOSWebKit = /*#__PURE__*/ once((): boolean => {
 /**
  * @internal
  */
+export const isDesktopSafari = /*#__PURE__*/ once((): boolean => {
+  return (
+    !isIOSWebKit() &&
+    navigator.vendor === "Apple Computer, Inc." &&
+    !("chrome" in window)
+  );
+});
+
+/**
+ * @internal
+ */
 export const isSmoothScrollSupported = /*#__PURE__*/ once((): boolean => {
   return "scrollBehavior" in getDocumentElement(document).style;
 });

--- a/src/core/scroller.ts
+++ b/src/core/scroller.ts
@@ -2,6 +2,7 @@ import {
   getCurrentDocument,
   getCurrentWindow,
   getDocumentElement,
+  isDesktopSafari,
   isIOSWebKit,
   isSmoothScrollSupported,
 } from "./environment.js";
@@ -336,7 +337,8 @@ export const createScroller = (
           // However iOS WebKit fires touch events only once at the beginning of momentum scrolling.
           // That means we have no reliable way to confirm still touched or not if user touches more than once during momentum scrolling...
           // This is a hack for the suspectable situations, inspired by https://github.com/prud/ios-overflow-scroll-to-top
-          if (isMomentumScrolling) {
+          // Desktop Safari also has delayed paint during scrolling, so we apply the same hack.
+          if (isMomentumScrolling || isDesktopSafari()) {
             const style = viewport.style;
             const prev = style[overflowKey];
             style[overflowKey] = "hidden";

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -10,7 +10,7 @@ import {
   takeCacheSnapshot,
   findIndex,
 } from "./cache.js";
-import { isIOSWebKit } from "./environment.js";
+import { isIOSWebKit, isDesktopSafari } from "./environment.js";
 import type {
   CacheSnapshot,
   InternalCacheSnapshot,
@@ -168,8 +168,9 @@ export const createVirtualStore = (
   const applyJump = (j: number) => {
     if (j) {
       if (
-        // In iOS WebKit browsers, updating scroll position will stop scrolling so it have to be deferred during scrolling.
-        (isIOSWebKit() && _scrollDirection !== SCROLL_IDLE) ||
+        // In WebKit browsers (iOS and desktop Safari), updating scroll position will stop scrolling so it have to be deferred during scrolling.
+        ((isIOSWebKit() || isDesktopSafari()) &&
+          _scrollDirection !== SCROLL_IDLE) ||
         // Before imperative smooth scrolling, we measure all items which may be visible during scrolling.
         // However, especially in Firefox, there are rare cases where items resize while scrolling, which can stop smooth scrolling.
         (_frozenRange && _scrollMode === SCROLL_BY_MANUAL_SCROLL)


### PR DESCRIPTION
Desktop Safari has the same scrollTop update delay behavior as iOS WebKit — when `scrollTop` is updated during active scrolling, the browser delays applying the value, which causes flickering when reverse-scrolling through items with varied sizes.

Currently the jump deferral in `applyJump` and the `overflow:hidden` repaint hack in the scroller only apply to iOS WebKit. This PR extends both behaviors to desktop Safari as well.

Changes:
- Added `isDesktopSafari` detection in `environment.ts`. It checks for Apple vendor, absence of Chrome, and non-iOS platform.
- In `store.ts`, `applyJump` now defers the jump when either `isIOSWebKit()` or `isDesktopSafari()` is true and scrolling is in progress.
- In `scroller.ts`, the `overflow:hidden` toggle that forces a browser repaint is applied to desktop Safari in addition to iOS momentum scrolling.

Reproducing the issue: open a list of items with varying heights in desktop Safari and scroll upward quickly — without this fix, items flicker or jump noticeably.

Fixes #362