### PR TITLE
Keep the top-anchored item pinned when rows above it grow

### DIFF
--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -364,7 +364,11 @@ export const createVirtualStore = (
                   _scrollMode === SCROLL_BY_NATIVE
                     ? // https://github.com/inokawa/virtua/issues/385
                       // https://github.com/inokawa/virtua/discussions/865
-                      itemOffset + itemSize < start
+                      // https://github.com/inokawa/virtua/issues/893
+                      // Use <= instead of < here so the item whose bottom rests
+                      // exactly on the viewport top (the row directly above an
+                      // item anchored to the top) is compensated too.
+                      itemOffset + itemSize <= start
                     : // https://github.com/inokawa/virtua/pull/868
                       itemOffset < start &&
                       itemOffset + itemSize < start + viewportSize;

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -365,7 +365,7 @@ export const createVirtualStore = (
                     ? // https://github.com/inokawa/virtua/issues/385
                       // https://github.com/inokawa/virtua/discussions/865
                       // https://github.com/inokawa/virtua/issues/893
-                      // Use <= instead of < here so the item whose bottom rests
+                      // Use "<=" instead of "<" here so the item whose bottom rests
                       // exactly on the viewport top (the row directly above an
                       // item anchored to the top) is compensated too.
                       itemOffset + itemSize <= start


### PR DESCRIPTION
Fixes https://github.com/inokawa/virtua/issues/893

See the original issue for the source code used in the video recordings below.

Before:

 

https://github.com/user-attachments/assets/51e6a9e1-c2df-46f3-a42a-035836574b59



After:

https://github.com/user-attachments/assets/fb837d98-6a4f-404b-a91f-4f17c10b169b

