### PR TITLE
Add itemProps prop to Svelte VList/Virtualizer

### DIFF
--- a/src/svelte/ListItem.svelte
+++ b/src/svelte/ListItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" generics="T">
   import { type Snippet, onDestroy } from "svelte";
   import { type ItemResizeObserver } from "../core/index.js";
-  import { styleToString } from "./utils.js";
+  import { styleToString, type ItemAttrs } from "./utils.js";
   import type { SvelteHTMLElements } from "svelte/elements";
 
   interface Props {
@@ -13,6 +13,7 @@
     hide: boolean;
     horizontal: boolean;
     resizer: ItemResizeObserver;
+    itemProps?: ItemAttrs | undefined;
   }
 
   let {
@@ -24,6 +25,7 @@
     hide,
     horizontal,
     resizer,
+    itemProps,
   }: Props = $props();
 
   let elementRef: HTMLDivElement;
@@ -48,6 +50,7 @@
       [horizontal ? "top" : "left"]: "0px",
       [horizontal ? "left" : "top"]: offset + "px",
       visibility: hide ? "hidden" : undefined,
+      ...itemProps?.style,
     };
     if (horizontal) {
       _style["display"] = "inline-flex";
@@ -55,8 +58,15 @@
 
     return styleToString(_style);
   });
+
+  // `style` is applied separately above, the rest (e.g. `class`) is spread onto the element
+  let itemRest = $derived.by(() => {
+    if (!itemProps) return undefined;
+    const { style: _style, ...rest } = itemProps;
+    return rest;
+  });
 </script>
 
-<svelte:element this={as} bind:this={elementRef} {style}>
+<svelte:element this={as} bind:this={elementRef} {style} {...itemRest}>
   {@render children(item, index)}
 </svelte:element>

--- a/src/svelte/VList.svelte
+++ b/src/svelte/VList.svelte
@@ -15,6 +15,7 @@
     horizontal,
     keepMounted,
     cache,
+    itemProps,
     children,
     onscroll,
     onscrollend,
@@ -82,6 +83,7 @@
     {horizontal}
     {keepMounted}
     {cache}
+    {itemProps}
     {onscroll}
     {onscrollend}
   />

--- a/src/svelte/VList.type.ts
+++ b/src/svelte/VList.type.ts
@@ -23,6 +23,7 @@ export interface VListProps<T>
       | "onscrollend"
       | "keepMounted"
       | "cache"
+      | "itemProps"
     >,
     ViewportComponentAttributes {}
 

--- a/src/svelte/Virtualizer.svelte
+++ b/src/svelte/Virtualizer.svelte
@@ -27,6 +27,7 @@
     getKey = defaultGetKey,
     as = "div",
     item: itemAs,
+    itemProps,
     scrollRef,
     bufferSize,
     itemSize,
@@ -187,6 +188,7 @@
       hide={stateVersion && store.$isUnmeasuredItem(index)}
       {horizontal}
       resizer={resizer.$observeItem}
+      itemProps={itemProps?.({ item, index })}
     />
   {/each}
 </svelte:element>

--- a/src/svelte/Virtualizer.type.ts
+++ b/src/svelte/Virtualizer.type.ts
@@ -1,6 +1,7 @@
 import { type Snippet } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 import { type CacheSnapshot, type ScrollToIndexOpts } from "../core/index.js";
+import { type ItemProps } from "./utils.js";
 
 /**
  * Props of {@link Virtualizer}.
@@ -29,6 +30,10 @@ export interface VirtualizerProps<T> {
    * @defaultValue "div"
    */
   item?: keyof SvelteHTMLElements;
+  /**
+   * A function that provides properties/attributes for item element
+   */
+  itemProps?: ItemProps<T>;
   /**
    * Extra item space in pixels to render before/after the viewport. The minimum value is 0. Lower value will give better performance but you can increase to avoid showing blank items in fast scrolling.
    * @defaultValue 200

--- a/src/svelte/utils.ts
+++ b/src/svelte/utils.ts
@@ -11,3 +11,20 @@ export const styleToString = (
 };
 
 export const defaultGetKey = (_data: unknown, i: number) => "_" + i;
+
+/**
+ * @internal
+ */
+export type ItemAttrs = {
+  [key: string]: any;
+  style?: Record<string, string | undefined>;
+  class?: string;
+};
+
+/**
+ * A function that provides properties/attributes for item element
+ */
+export type ItemProps<T = unknown> = (payload: {
+  item: T;
+  index: number;
+}) => ItemAttrs | undefined;

--- a/stories/svelte/advanced/Sticky Group.stories.ts
+++ b/stories/svelte/advanced/Sticky Group.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/svelte-vite";
+import { VList } from "../../../src/svelte";
+import StickyGroupComponent from "./StickyGroup.svelte";
+
+export default {
+  component: VList,
+} satisfies Meta;
+
+export const StickyGroup: StoryObj = {
+  render: () => ({
+    Component: StickyGroupComponent,
+  }),
+};

--- a/stories/svelte/advanced/StickyGroup.svelte
+++ b/stories/svelte/advanced/StickyGroup.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import { VList, type VListHandle } from "../../../src/svelte";
+
+  const sizes = [20, 40, 180, 77];
+  const stickyIndexes = [0, 100, 200, 300, 400, 500, 600, 700, 800, 900];
+  const data = Array.from({ length: 1000 }).map((_, i) => sizes[i % 4]!);
+
+  let ref: VListHandle;
+  let activeIndex = $state(0);
+
+  const itemProps = ({ index }: { index: number }) => {
+    if (index % 100 !== 0) return undefined;
+    return {
+      style: {
+        "z-index": "1",
+        ...(activeIndex === index ? { position: "sticky", top: "0" } : {}),
+      },
+    };
+  };
+
+  const handleScroll = (offset: number) => {
+    if (!ref) return;
+    const start = ref.findItemIndex(offset);
+    activeIndex = [...stickyIndexes].reverse().find((i) => start >= i)!;
+  };
+</script>
+
+<VList
+  bind:this={ref}
+  {data}
+  style="height: 100vh;"
+  {itemProps}
+  keepMounted={[activeIndex]}
+  onscroll={handleScroll}
+>
+  {#snippet children(item, index)}
+    <div
+      style="
+        height: {item}px;
+        background: {index % 100 === 0 ? 'yellow' : 'white'};
+        border-bottom: solid 1px #ccc;
+      "
+    >
+      {index}
+    </div>
+  {/snippet}
+</VList>


### PR DESCRIPTION
## Summary

We needed sticky date-separator headers in a chat-style virtualized list (Svelte), similar to what's already possible in React/Vue/Solid via the "Sticky Group" pattern. The Svelte package didn't support this because `Virtualizer`/`VList` only accepted `item` as an HTML tag name — there was no way to attach extra `style`/`class`/attributes to a specific item's wrapper element, which is required to flip an item from `position: absolute` to `position: sticky` at scroll time.

Rather than hack around this at the story/consumer level, we added first-class `itemProps` support to the Svelte package (`src/svelte`), mirroring the existing Vue `itemProps` API:

- `Virtualizer`/`VList` now accept an `itemProps?: (payload: { item, index }) => { style?, class?, ...attrs }` prop.
- The returned `style` is merged on top of the item wrapper's base positioning styles (so overrides like `position`/`top` take effect), and any other returned attributes (e.g. `class`) are spread onto the wrapper element.
- `WindowVirtualizer` is untouched — Vue doesn't expose `itemProps` there either, so there's no parity gap to close.

With that in place, we ported the existing "Sticky Group" Storybook story (already present for React/Vue/Solid) to Svelte, demonstrating sticky group headers built entirely on public API — no internal hacks needed.

No dedicated unit test was added for `itemProps`, matching the existing convention in this repo (the Vue `itemProps` implementation has no dedicated unit test either) — coverage here is the existing `VList`/`Virtualizer` SSR spec suite plus manual verification via the new Storybook story.

## Test plan

- [ ] `npm run test -- --project=svelte` passes (existing suite, unchanged)
- [ ] `npm run check:svelte` reports no new errors
- [ ] `npm run storybook:svelte` → "advanced/Sticky Group" story: scroll through the list and confirm the active group header (0, 100, 200, …) sticks to the top and hands off correctly at each boundary
