### PR TITLE
svelte: avoid observing elements if the component is already un-mounted

### DIFF
--- a/spec/svelte.ts
+++ b/spec/svelte.ts
@@ -1,6 +1,9 @@
 import { vi } from "vitest";
 import { render as _render } from "@testing-library/svelte";
 
+export const renderSync = (...args: Parameters<typeof _render>) =>
+  _render(...args);
+
 export const render = async (...args: Parameters<typeof _render>) => {
   const res = _render(...args);
   let same = false;

--- a/src/svelte/Virtualizer.spec.ts
+++ b/src/svelte/Virtualizer.spec.ts
@@ -1,6 +1,6 @@
-import { it, expect, describe, afterEach } from "vitest";
-import { cleanup } from "@testing-library/svelte";
-import { createRawSnippet } from "svelte";
+import { it, expect, describe, afterEach, vi } from "vitest";
+import { cleanup, render as renderRaw } from "@testing-library/svelte";
+import { createRawSnippet, tick } from "svelte";
 import Host from "../../spec/svelte/VirtualizerHost.svelte";
 import { setupResizeJsDom } from "../../spec/dom.js";
 import { render } from "../../spec/svelte.js";
@@ -118,5 +118,31 @@ describe("horizontal", () => {
       props: { data: range(3), horizontal: true, children: componentSnippet },
     });
     expect(container.innerHTML).toMatchSnapshot();
+  });
+});
+
+describe("unmount before tick resolves", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("should not invoke ResizeObserver callback after unmount", async () => {
+    const ResizeObserver = vi.fn();
+    vi.stubGlobal("ResizeObserver", ResizeObserver);
+
+    // Render synchronously; `tick().then(...)` is still pending
+    const result = renderRaw(Host, {
+      props: { data: range(10), children: itemSnippet },
+    });
+
+    // Unmount before the `tick()` resolves.
+    result.unmount();
+
+    // Wait for the `tick().then(...)` to resolve
+    await tick();
+
+    // The `ResizeObserver` should never have been created, since we disposed
+    // of it's wrapper before we observed any DOM nodes
+    expect(ResizeObserver).not.toHaveBeenCalled();
   });
 });

--- a/src/svelte/Virtualizer.spec.ts
+++ b/src/svelte/Virtualizer.spec.ts
@@ -1,9 +1,9 @@
-import { it, expect, describe, afterEach, vi } from "vitest";
-import { cleanup, render as renderRaw } from "@testing-library/svelte";
+import { it, expect, describe, afterEach, onTestFinished, vi } from "vitest";
+import { cleanup } from "@testing-library/svelte";
 import { createRawSnippet, tick } from "svelte";
 import Host from "../../spec/svelte/VirtualizerHost.svelte";
 import { setupResizeJsDom } from "../../spec/dom.js";
-import { render } from "../../spec/svelte.js";
+import { render, renderSync } from "../../spec/svelte.js";
 
 const ITEM_HEIGHT = 50;
 const ITEM_WIDTH = 100;
@@ -121,28 +121,14 @@ describe("horizontal", () => {
   });
 });
 
-describe("unmount before tick resolves", () => {
-  afterEach(() => {
-    vi.unstubAllGlobals();
+it("should not observe if unmounted before tick resolves", async () => {
+  const observe = vi.spyOn(global.ResizeObserver.prototype, "observe");
+  onTestFinished(() => observe.mockRestore());
+  // render without awaiting to unmount while tick() in onMount is pending
+  const { unmount } = renderSync(Host, {
+    props: { data: range(10), children: itemSnippet },
   });
-
-  it("should not invoke ResizeObserver callback after unmount", async () => {
-    const ResizeObserver = vi.fn();
-    vi.stubGlobal("ResizeObserver", ResizeObserver);
-
-    // Render synchronously; `tick().then(...)` is still pending
-    const result = renderRaw(Host, {
-      props: { data: range(10), children: itemSnippet },
-    });
-
-    // Unmount before the `tick()` resolves.
-    result.unmount();
-
-    // Wait for the `tick().then(...)` to resolve
-    await tick();
-
-    // The `ResizeObserver` should never have been created, since we disposed
-    // of it's wrapper before we observed any DOM nodes
-    expect(ResizeObserver).not.toHaveBeenCalled();
-  });
+  unmount();
+  await tick();
+  expect(observe).not.toHaveBeenCalled();
 });

--- a/src/svelte/Virtualizer.svelte
+++ b/src/svelte/Virtualizer.svelte
@@ -70,6 +70,8 @@
   let totalSize = $derived(stateVersion && store.$getTotalSize());
   let negative = $derived(stateVersion && scroller.$isNegative());
 
+  let componentIsMounted = false;
+
   let indexes = $derived.by(() => {
     // https://github.com/inokawa/virtua/pull/847
     const len = data.length;
@@ -97,10 +99,14 @@
   });
 
   onMount(() => {
+    componentIsMounted = true;
+
     const container = containerRef!;
     const assignRef = (scrollable: HTMLElement) => {
-      resizer.$observeRoot(scrollable);
-      scroller.$observe(container, scrollable);
+      if (componentIsMounted) {
+        resizer.$observeRoot(scrollable);
+        scroller.$observe(container, scrollable);
+      }
     };
     // parent's ref may not exist on mount https://github.com/inokawa/virtua/issues/603 https://github.com/inokawa/virtua/issues/690
     tick().then(() => {
@@ -112,6 +118,8 @@
     });
   });
   onDestroy(() => {
+    componentIsMounted = false;
+
     store.$dispose();
     resizer.$dispose();
     scroller.$dispose();

--- a/src/svelte/Virtualizer.svelte
+++ b/src/svelte/Virtualizer.svelte
@@ -70,8 +70,6 @@
   let totalSize = $derived(stateVersion && store.$getTotalSize());
   let negative = $derived(stateVersion && scroller.$isNegative());
 
-  let componentIsMounted = false;
-
   let indexes = $derived.by(() => {
     // https://github.com/inokawa/virtua/pull/847
     const len = data.length;
@@ -99,27 +97,27 @@
   });
 
   onMount(() => {
-    componentIsMounted = true;
-
+    let unmounted = false;
     const container = containerRef!;
-    const assignRef = (scrollable: HTMLElement) => {
-      if (componentIsMounted) {
-        resizer.$observeRoot(scrollable);
-        scroller.$observe(container, scrollable);
-      }
-    };
     // parent's ref may not exist on mount https://github.com/inokawa/virtua/issues/603 https://github.com/inokawa/virtua/issues/690
     tick().then(() => {
+      // https://github.com/inokawa/virtua/pull/914
+      if (unmounted) return;
+      const assignRef = (scrollable: HTMLElement) => {
+        resizer.$observeRoot(scrollable);
+        scroller.$observe(container, scrollable);
+      };
       if (scrollRef) {
         assignRef(scrollRef);
       } else {
         assignRef(container.parentElement!);
       }
     });
+    return () => {
+      unmounted = true;
+    };
   });
   onDestroy(() => {
-    componentIsMounted = false;
-
     store.$dispose();
     resizer.$dispose();
     scroller.$dispose();


### PR DESCRIPTION
We came across a race condition when using Virtua's Svelte support in our application: a component can be un-mounted before the `tick()` delays observation resolves, meaning we're now observing elements that aren't mounted anymore. This caused some downstream failures in our application's test suite.

I looked into whether any of the other frameworks have a similar issue, but it seems like setup is synchronous or has some other form of guard in place in all other cases, so I chose to fix this _just_ in the Svelte implementation since that seems to be the only one affected by this bug.