### PR TITLE
feat: add Octane virtual list adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![npm](https://img.shields.io/npm/v/virtua) ![npm bundle size](https://img.shields.io/bundlephobia/minzip/virtua) ![npm](https://img.shields.io/npm/dw/virtua) [![Best of JS](https://img.shields.io/endpoint?url=https://bestofjs-serverless.now.sh/api/project-badge?fullName=inokawa%2Fvirtua%26since=daily)](https://bestofjs.org/projects/virtua) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/inokawa/virtua) [![check](https://github.com/inokawa/virtua/actions/workflows/check.yml/badge.svg)](https://github.com/inokawa/virtua/actions/workflows/check.yml) [![demo](https://github.com/inokawa/virtua/actions/workflows/demo.yml/badge.svg)](https://github.com/inokawa/virtua/actions/workflows/demo.yml)
 
-> A zero-config, fast and small (~3kB) virtual list (and grid) component for [React](https://github.com/facebook/react), [Vue](https://vuejs.org/), [Solid](https://www.solidjs.com/), [Svelte](https://svelte.dev/) and [Angular](https://angular.dev/).
+> A zero-config, fast and small (~3kB) virtual list (and grid) component for [React](https://github.com/facebook/react), [Vue](https://vuejs.org/), [Solid](https://www.solidjs.com/), [Svelte](https://svelte.dev/), [Angular](https://angular.dev/) and [Octane](https://github.com/octanejs/octane).
 
 ![example](./example.gif)
 
@@ -16,7 +16,7 @@ This project is a challenge to rethink virtualization. The goals are...
 - **Fast:** Natural virtual scrolling needs optimization in many aspects (eliminate frame drops by reducing CPU usage and GC, reduce [synchronous layout recalculation](https://gist.github.com/paulirish/5d52fb081b3570c81e3a), reduce visual jumps on repaint, optimize with CSS, optimize for JIT, optimize for frameworks, etc). We are trying to combine the best of them.
 - **Small:** Its bundle size should be small as much as possible to be friendly with modern web development. Currently each components are ~3kB gzipped and tree-shakeable.
 - **Flexible:** Aiming to support many usecases - fixed size, dynamic size, horizontal scrolling, reverse scrolling, RTL, mobile, infinite scrolling, scroll restoration, DnD, keyboard navigation, sticky, placeholder and more. See [live demo](#demo).
-- **Framework agnostic:** [React](https://react.dev/), [Vue](https://vuejs.org/), [Solid](https://www.solidjs.com/), [Svelte](https://svelte.dev/) and [Angular](https://angular.dev/) are supported. We could support other frameworks in the future.
+- **Framework agnostic:** [React](https://react.dev/), [Vue](https://vuejs.org/), [Solid](https://www.solidjs.com/), [Svelte](https://svelte.dev/), [Angular](https://angular.dev/) and [Octane](https://github.com/octanejs/octane) are supported. We could support other frameworks in the future.
 
 ## Demo
 
@@ -313,6 +313,33 @@ export class App {
 }
 ```
 
+### Octane
+
+`octane >= 0.1.36` is required. The Octane entry exports `VList`,
+`Virtualizer`, and `WindowVirtualizer`; the experimental grid is not yet part of
+this adapter.
+
+```tsx
+import { VList } from "virtua/octane";
+
+const data = Array.from({ length: 1000 }, (_, index) => ({
+  id: index,
+  label: `Item ${index}`,
+}));
+
+export function App() {
+  return (
+    <VList data={data} style={{ height: 800 }}>
+      {(item, index) => (
+        <div key={item.id} style={{ height: 50 }}>
+          {item.label}
+        </div>
+      )}
+    </VList>
+  );
+}
+```
+
 ### Other bindings
 
 - [vanilla-virtua](https://github.com/aabccd021/vanilla-virtua): virtua for vanilla js
@@ -390,9 +417,9 @@ And do not use index of items as `key`, especially when you want to toggle `shif
 
 `viewportSize` will be calculated by ResizeObserver so it's 0 until the first measurement.
 
-#### What is `Cannot find module 'virtua/vue(solid|svelte|angular)' or its corresponding type declarations` error?
+#### What is `Cannot find module 'virtua/vue(solid|svelte|angular|octane)' or its corresponding type declarations` error?
 
-This package uses [exports of package.json](https://nodejs.org/api/packages.html#package-entry-points) for entry point of Vue/Solid/Svelte/Angular adapter. This field can't be resolved in TypeScript with `moduleResolution: node`. Try `moduleResolution: bundler` or `moduleResolution: nodenext` instead.
+This package uses [exports of package.json](https://nodejs.org/api/packages.html#package-entry-points) for entry point of Vue/Solid/Svelte/Angular/Octane adapters. This field can't be resolved in TypeScript with `moduleResolution: node`. Try `moduleResolution: bundler` or `moduleResolution: nodenext` instead.
 
 ## Comparison
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![npm](https://img.shields.io/npm/v/virtua) ![npm bundle size](https://img.shields.io/bundlephobia/minzip/virtua) ![npm](https://img.shields.io/npm/dw/virtua) [![Best of JS](https://img.shields.io/endpoint?url=https://bestofjs-serverless.now.sh/api/project-badge?fullName=inokawa%2Fvirtua%26since=daily)](https://bestofjs.org/projects/virtua) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/inokawa/virtua) [![check](https://github.com/inokawa/virtua/actions/workflows/check.yml/badge.svg)](https://github.com/inokawa/virtua/actions/workflows/check.yml) [![demo](https://github.com/inokawa/virtua/actions/workflows/demo.yml/badge.svg)](https://github.com/inokawa/virtua/actions/workflows/demo.yml)
 
-> A zero-config, fast and small (~3kB) virtual list (and grid) component for [React](https://github.com/facebook/react), [Vue](https://vuejs.org/), [Solid](https://www.solidjs.com/), [Svelte](https://svelte.dev/), [Angular](https://angular.dev/) and [Octane](https://github.com/octanejs/octane).
+> A zero-config, fast and small (~3kB) virtual list component for [React](https://github.com/facebook/react), [Vue](https://vuejs.org/), [Solid](https://www.solidjs.com/), [Svelte](https://svelte.dev/), [Angular](https://angular.dev/) and [Octane](https://github.com/octanejs/octane), with grid support on selected adapters.
 
 ![example](./example.gif)
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -80,6 +80,10 @@ export default [
               target: ["./src/angular/**/*"],
               from: ["./src/!(core|angular)/**/*", "./src/core/!(index.ts)"],
             },
+            {
+              target: ["./src/octane/**/*"],
+              from: ["./src/!(core|octane)/**/*", "./src/core/!(index.ts)"],
+            },
           ],
         },
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@faker-js/faker": "^10.3.0",
         "@formkit/auto-animate": "^0.10.0",
         "@mui/material": "^9.0.0",
+        "@octanejs/testing-library": "^0.1.33",
         "@playwright/test": "^1.56.0",
         "@radix-ui/colors": "^3.0.0",
         "@radix-ui/react-icons": "^1.3.2",
@@ -70,6 +71,7 @@
         "eslint-plugin-solid": "^0.14.5",
         "eslint-plugin-vue": "^10.10.0",
         "jsdom": "^29.0.0",
+        "octane": "^0.1.36",
         "prettier": "^3.8.3",
         "prettier-plugin-svelte": "^4.0.0",
         "re-resizable": "^6.11.2",
@@ -108,6 +110,7 @@
       "peerDependencies": {
         "@angular/common": ">=20.0.0",
         "@angular/core": ">=20.0.0",
+        "octane": ">=0.1.36",
         "react": ">=16.14.0",
         "react-dom": ">=16.14.0",
         "solid-js": ">=1.0",
@@ -119,6 +122,9 @@
           "optional": true
         },
         "@angular/core": {
+          "optional": true
+        },
+        "octane": {
           "optional": true
         },
         "react": {
@@ -6144,6 +6150,19 @@
         "webpack": "^5.54.0"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
+      "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -6180,6 +6199,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@octanejs/testing-library": {
+      "version": "0.1.33",
+      "resolved": "https://registry.npmjs.org/@octanejs/testing-library/-/testing-library-0.1.33.tgz",
+      "integrity": "sha512-AxiZIkZt7/wRUHo3q2U+Yb+aAUiGhVkajJyH90MaHf8zPpmYXYwHiDcg7qGDg8zOWi82QBpfTgnk1Oq3R4oBcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@testing-library/dom": "^10.4.1"
+      },
+      "engines": {
+        "node": ">=22.22.2"
+      },
+      "peerDependencies": {
+        "octane": "0.1.36"
       }
     },
     "node_modules/@one-ini/wasm": {
@@ -9490,9 +9525,9 @@
       }
     },
     "node_modules/@sveltejs/acorn-typescript": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
-      "integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.12.tgz",
+      "integrity": "sha512-J1jNYG23QWd67UfrQSFHtjhV37r9mVi0gdc12A3MWPldOjRK35Xk+um+qACPVjgw3AleiqoyEAhok8Wm3q46NA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -9836,6 +9871,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@tsrx/core": {
+      "version": "0.1.56",
+      "resolved": "https://registry.npmjs.org/@tsrx/core/-/core-0.1.56.tgz",
+      "integrity": "sha512-SZ+lani1n0yR4pFqOxclfWvU4Pvd3i9d6aptShicAzC3IYW2yQrsNJoG5ZqoVai9A3ZRikkO4CY8/HK+ksNp1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5",
+        "@noble/hashes": "^2.2.0",
+        "@sveltejs/acorn-typescript": "^1.0.11",
+        "@types/estree": "^1.0.8",
+        "@types/estree-jsx": "^1.0.5",
+        "acorn": "^8.17.0",
+        "esrap": "^2.3.0",
+        "is-reference": "^3.0.3",
+        "magic-string": "^0.30.18",
+        "zimmerframe": "^1.1.2"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -10220,9 +10274,9 @@
       "peer": true
     },
     "node_modules/@types/react": {
-      "version": "19.2.15",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
-      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12376,9 +12430,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -14679,9 +14733,9 @@
       "license": "MIT"
     },
     "node_modules/devalue": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
-      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.0.tgz",
+      "integrity": "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==",
       "dev": true,
       "license": "MIT"
     },
@@ -15889,9 +15943,9 @@
       }
     },
     "node_modules/esrap": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.9.tgz",
-      "integrity": "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.3.2.tgz",
+      "integrity": "sha512-40GyiEJevYKXzYTHtZkFqAgTjLOuFcaXMao8TPyOlnWTlkHDlvZ6mPMJaJyOqVwrVCgomEG1WhJd81w0X+IcCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21440,6 +21494,46 @@
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
+      "license": "MIT"
+    },
+    "node_modules/octane": {
+      "version": "0.1.36",
+      "resolved": "https://registry.npmjs.org/octane/-/octane-0.1.36.tgz",
+      "integrity": "sha512-egscdNROPtLh0Kd4TijYXr3/rVdjyDVCr7r4/mArAAjAuvqhRVsYcLDGr88MT4JSvZwDtISsOALNZY2crLETjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tsrx/core": "^0.1.56",
+        "@types/react": "^19.2.17",
+        "devalue": "^5.8.2",
+        "es-module-lexer": "^1.7.0",
+        "esrap": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=22.22.2"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "vite": "^8.0.16"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/octane/node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/on-finished": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "virtua",
   "version": "0.50.1",
-  "description": "A zero-config, fast and small (~3kB) virtual list (and grid) component for React, Vue, Solid, Svelte and Angular.",
+  "description": "A zero-config, fast and small (~3kB) virtual list (and grid) component for React, Vue, Solid, Svelte, Angular and Octane.",
   "main": "lib/index.cjs",
   "module": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -33,6 +33,12 @@
       "types": "./lib/angular/index.d.ts",
       "default": "./lib/angular/index.js"
     },
+    "./octane": {
+      "types": "./lib/octane/index.d.ts",
+      "browser": "./lib/octane/client/index.js",
+      "node": "./lib/octane/server/index.js",
+      "default": "./lib/octane/client/index.js"
+    },
     "./unstable_core": {
       "types": "./lib/core/index.d.ts",
       "require": "./lib/core/index.cjs",
@@ -44,14 +50,15 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "rimraf lib && vite build -c vite.build.config.ts -m react && vite build -c vite.build.config.ts -m vue && vite build -c vite.build.config.ts -m solid && vite build -c vite.build.config.ts -m solid-ssr && vite build -c vite.build.config.ts -m core && vite build -c vite.build.config.ts -m svelte && vite build -c vite.build.config.ts -m angular && ngc -p tsconfig.angular.build.json && node scripts/copy-angular-dts.js",
-    "tsc": "tsc -p . --noEmit",
-    "test": "vitest run --project=unit --project=react --project=vue --project=solid --project=svelte --project=angular",
-    "lint": "eslint '{src,e2e}/**/*.{js,jsx,ts,tsx}' --cache",
+    "build": "rimraf lib && vite build -c vite.build.config.ts -m react && vite build -c vite.build.config.ts -m vue && vite build -c vite.build.config.ts -m solid && vite build -c vite.build.config.ts -m solid-ssr && vite build -c vite.build.config.ts -m core && vite build -c vite.build.config.ts -m svelte && vite build -c vite.build.config.ts -m angular && ngc -p tsconfig.angular.build.json && node scripts/copy-angular-dts.js && vite build -c vite.build.config.ts -m octane && vite build -c vite.build.config.ts -m octane-ssr && node scripts/build-octane-dts.js && node scripts/check-octane-package.js",
+    "tsc": "tsc -p . --noEmit && node scripts/build-octane-dts.js --check",
+    "test": "vitest run --project=unit --project=react --project=vue --project=solid --project=svelte --project=angular --project=octane --project=octane-ssr --project=octane-browser",
+    "lint": "eslint '{src,e2e}/**/*.{js,jsx,ts,tsx}' 'scripts/**/*.js' --cache",
     "format": "prettier '**/*.{js,ts,jsx,tsx,vue,svelte}' --write --cache",
     "format:ci": "prettier '**/*.{js,ts,jsx,tsx,vue,svelte}' -l",
     "check:svelte": "svelte-check --tsconfig ./tsconfig.svelte.json",
     "check:angular": "ngc -p tsconfig.angular.json --noEmit",
+    "check:octane": "node scripts/check-octane-package.js",
     "storybook": "storybook dev -p 6006",
     "storybook:rtl": "STORYBOOK_RTL=1 npm run storybook",
     "storybook:vue": "STORYBOOK_VUE=1 npm run storybook",
@@ -90,6 +97,7 @@
     "@faker-js/faker": "^10.3.0",
     "@formkit/auto-animate": "^0.10.0",
     "@mui/material": "^9.0.0",
+    "@octanejs/testing-library": "^0.1.33",
     "@playwright/test": "^1.56.0",
     "@radix-ui/colors": "^3.0.0",
     "@radix-ui/react-icons": "^1.3.2",
@@ -128,6 +136,7 @@
     "eslint-plugin-solid": "^0.14.5",
     "eslint-plugin-vue": "^10.10.0",
     "jsdom": "^29.0.0",
+    "octane": "^0.1.36",
     "prettier": "^3.8.3",
     "prettier-plugin-svelte": "^4.0.0",
     "re-resizable": "^6.11.2",
@@ -177,6 +186,7 @@
   "peerDependencies": {
     "@angular/common": ">=20.0.0",
     "@angular/core": ">=20.0.0",
+    "octane": ">=0.1.36",
     "react": ">=16.14.0",
     "react-dom": ">=16.14.0",
     "solid-js": ">=1.0",
@@ -188,6 +198,9 @@
       "optional": true
     },
     "@angular/core": {
+      "optional": true
+    },
+    "octane": {
       "optional": true
     },
     "react": {
@@ -217,6 +230,7 @@
     "solid",
     "svelte",
     "angular",
+    "octane",
     "ui",
     "headless",
     "list",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "virtua",
   "version": "0.50.1",
-  "description": "A zero-config, fast and small (~3kB) virtual list (and grid) component for React, Vue, Solid, Svelte, Angular and Octane.",
+  "description": "A zero-config, fast and small (~3kB) virtual list component for React, Vue, Solid, Svelte, Angular and Octane, with grid support on selected adapters.",
   "main": "lib/index.cjs",
   "module": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/scripts/build-octane-dts.js
+++ b/scripts/build-octane-dts.js
@@ -1,0 +1,113 @@
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+import ts from "typescript";
+
+const projectRoot = resolve(import.meta.dirname, "..");
+const sourceRoot = join(projectRoot, "src");
+const checking = process.argv.includes("--check");
+const temporaryRoot = mkdtempSync(join(tmpdir(), "virtua-octane-types-"));
+const temporarySource = join(temporaryRoot, "src");
+const temporaryOutput = join(temporaryRoot, "out");
+
+const filesUnder = (directory) =>
+  readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    return entry.isDirectory() ? filesUnder(path) : [path];
+  });
+
+const replaceSpecifiers = (source, extension) =>
+  source.replace(
+    /(\b(?:from\s*|import\s*\(\s*)["'])(\.{1,2}\/[^"']+\.(?:tsrx|tsx))(["'])/g,
+    (_match, before, specifier, after) =>
+      `${before}${specifier.replace(/\.(?:tsrx|tsx)$/, extension)}${after}`,
+  );
+
+try {
+  symlinkSync(
+    join(projectRoot, "node_modules"),
+    join(temporaryRoot, "node_modules"),
+    "dir",
+  );
+
+  const sources = ["core", "octane"].flatMap((area) =>
+    filesUnder(join(sourceRoot, area)).filter(
+      (file) =>
+        (file.endsWith(".ts") || file.endsWith(".tsrx")) &&
+        !file.includes(".spec."),
+    ),
+  );
+
+  for (const source of sources) {
+    const sourcePath = relative(sourceRoot, source).replace(/\.tsrx$/, ".tsx");
+    const destination = join(temporarySource, sourcePath);
+    mkdirSync(dirname(destination), { recursive: true });
+    writeFileSync(
+      destination,
+      replaceSpecifiers(readFileSync(source, "utf8"), ".tsx"),
+    );
+  }
+
+  const roots = sources
+    .filter((file) => file.startsWith(join(sourceRoot, "octane")))
+    .map((file) =>
+      join(
+        temporarySource,
+        relative(sourceRoot, file).replace(/\.tsrx$/, ".tsx"),
+      ),
+    );
+  const program = ts.createProgram(roots, {
+    declaration: true,
+    emitDeclarationOnly: true,
+    esModuleInterop: true,
+    allowImportingTsExtensions: true,
+    jsx: ts.JsxEmit.ReactJSX,
+    jsxImportSource: "octane",
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    noEmit: checking,
+    noUnusedLocals: true,
+    noUnusedParameters: true,
+    outDir: temporaryOutput,
+    rootDir: temporarySource,
+    skipLibCheck: true,
+    strict: true,
+    target: ts.ScriptTarget.ESNext,
+    types: ["node"],
+  });
+  const diagnostics = ts.getPreEmitDiagnostics(program);
+  if (diagnostics.length > 0) {
+    throw new Error(
+      ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+        getCanonicalFileName: (file) => file,
+        getCurrentDirectory: () => projectRoot,
+        getNewLine: () => "\n",
+      }),
+    );
+  }
+
+  if (!checking) {
+    const result = program.emit();
+    if (result.emitSkipped)
+      throw new Error("Octane declaration emit was skipped.");
+    const generated = join(temporaryOutput, "octane");
+    const destination = join(projectRoot, "lib", "octane");
+    cpSync(generated, destination, { recursive: true });
+    for (const entry of readdirSync(destination)) {
+      if (!entry.endsWith(".d.ts")) continue;
+      const file = join(destination, entry);
+      writeFileSync(file, replaceSpecifiers(readFileSync(file, "utf8"), ".js"));
+    }
+  }
+} finally {
+  rmSync(temporaryRoot, { force: true, recursive: true });
+}

--- a/scripts/check-octane-package.js
+++ b/scripts/check-octane-package.js
@@ -44,6 +44,20 @@ assert.ok(
   (clientSource.match(/Symbol\(/g) ?? []).length >= 20,
   "Octane bundle is missing generated hook call-site slots",
 );
+// The marker line comment tells the consumer's octane compiler to skip hook
+// re-slotting of these pre-compiled bundles. It must survive minification,
+// so it is injected with postBanner (terser strips a plain banner).
+const noSlotMarker = /\/\/\s*octane-no-slot\b/;
+assert.match(
+  clientSource,
+  noSlotMarker,
+  "octane-no-slot marker is missing from the client bundle",
+);
+assert.match(
+  serverSource,
+  noSlotMarker,
+  "octane-no-slot marker is missing from the server bundle",
+);
 
 const octaneGzipSize = gzipSync(clientSource).byteLength;
 const reactGzipSize = gzipSync(readFileSync(reactEntry)).byteLength;

--- a/scripts/check-octane-package.js
+++ b/scripts/check-octane-package.js
@@ -1,0 +1,115 @@
+import { strict as assert } from "node:assert";
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { gzipSync } from "node:zlib";
+import { octane } from "octane/compiler/vite";
+import ts from "typescript";
+import { build } from "vite";
+
+const projectRoot = resolve(import.meta.dirname, "..");
+const clientEntry = join(projectRoot, "lib/octane/client/index.js");
+const serverEntry = join(projectRoot, "lib/octane/server/index.js");
+const typeEntry = join(projectRoot, "lib/octane/index.d.ts");
+const reactEntry = join(projectRoot, "lib/index.js");
+
+for (const file of [clientEntry, serverEntry, typeEntry]) {
+  assert.doesNotThrow(
+    () => readFileSync(file),
+    `Missing Octane artifact: ${file}`,
+  );
+}
+
+const clientSource = readFileSync(clientEntry, "utf8");
+const serverSource = readFileSync(serverEntry, "utf8");
+const declarations = readdirSync(join(projectRoot, "lib/octane"))
+  .filter((entry) => entry.endsWith(".d.ts"))
+  .map((entry) => readFileSync(join(projectRoot, "lib/octane", entry), "utf8"))
+  .join("\n");
+assert.doesNotMatch(clientSource, /["']react(?:-dom)?(?:\/[^"']*)?["']/);
+assert.doesNotMatch(serverSource, /["']react(?:-dom)?(?:\/[^"']*)?["']/);
+assert.doesNotMatch(serverSource, /from\s+["']octane["']/);
+assert.doesNotMatch(declarations, /(?:from\s+["']react["']|@types\/react)/);
+// Plain .ts custom hooks must receive compiler-generated slots, and .tsrx
+// callers must scope each invocation through withSlot.
+assert.match(clientSource, /hookSlots\s+as\s+\w+/);
+assert.match(clientSource, /withSlot\s+as\s+\w+/);
+assert.ok(
+  (clientSource.match(/Symbol\(/g) ?? []).length >= 20,
+  "Octane bundle is missing generated hook call-site slots",
+);
+
+const octaneGzipSize = gzipSync(clientSource).byteLength;
+const reactGzipSize = gzipSync(readFileSync(reactEntry)).byteLength;
+assert.ok(
+  octaneGzipSize <= reactGzipSize,
+  `Octane bundle (${octaneGzipSize} B gzip) exceeds React (${reactGzipSize} B gzip)`,
+);
+
+const serverExports = await import("virtua/octane");
+for (const name of ["VList", "Virtualizer", "WindowVirtualizer"]) {
+  assert.equal(
+    typeof serverExports[name],
+    "function",
+    `Missing ${name} export`,
+  );
+}
+
+const temporaryRoot = mkdtempSync(join(projectRoot, ".octane-consumer-"));
+try {
+  const entry = join(temporaryRoot, "consumer.tsrx");
+  const consumerSource = `import { VList, type VListHandle } from "virtua/octane";
+const items = [{ id: 1, label: "one" }];
+const listRef: { current: VListHandle | null } = { current: null };
+export function Consumer() {
+  return <VList ref={listRef} data={items}>{(item: { id: number; label: string }) => <div key={item.id}>{item.label}</div>}</VList>;
+}
+`;
+  writeFileSync(entry, consumerSource);
+  const typeFixture = join(temporaryRoot, "consumer.tsx");
+  writeFileSync(typeFixture, consumerSource);
+
+  const typeProgram = ts.createProgram([typeFixture], {
+    jsx: ts.JsxEmit.ReactJSX,
+    jsxImportSource: "octane",
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    noEmit: true,
+    skipLibCheck: true,
+    strict: true,
+    target: ts.ScriptTarget.ESNext,
+  });
+  const diagnostics = ts.getPreEmitDiagnostics(typeProgram);
+  assert.equal(
+    diagnostics.length,
+    0,
+    ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+      getCanonicalFileName: (file) => file,
+      getCurrentDirectory: () => projectRoot,
+      getNewLine: () => "\n",
+    }),
+  );
+
+  await build({
+    configFile: false,
+    logLevel: "silent",
+    plugins: [octane()],
+    resolve: { extensions: [".tsrx", ".ts", ".mjs", ".js", ".json"] },
+    build: {
+      outDir: join(temporaryRoot, "dist"),
+      lib: { entry, formats: ["es"], fileName: () => "consumer.js" },
+      write: true,
+    },
+  });
+
+  const bundle = readFileSync(join(temporaryRoot, "dist/consumer.js"), "utf8");
+  assert.doesNotMatch(bundle, /["']react(?:-dom)?(?:\/[^"']*)?["']/);
+} finally {
+  rmSync(temporaryRoot, { force: true, recursive: true });
+}

--- a/scripts/check-octane-package.js
+++ b/scripts/check-octane-package.js
@@ -1,4 +1,5 @@
 import { strict as assert } from "node:assert";
+import { execFileSync } from "node:child_process";
 import {
   mkdtempSync,
   readFileSync,
@@ -75,8 +76,43 @@ for (const name of ["VList", "Virtualizer", "WindowVirtualizer"]) {
   );
 }
 
-const temporaryRoot = mkdtempSync(join(projectRoot, ".octane-consumer-"));
+const temporaryRoot = mkdtempSync(join(tmpdir(), "virtua-octane-consumer-"));
 try {
+  // Reason: install the exact publishable tarball in an isolated directory so
+  // workspace links cannot hide missing files or dependency declarations.
+  const packOutput = execFileSync(
+    "npm",
+    ["pack", "--pack-destination", temporaryRoot],
+    {
+      cwd: projectRoot,
+      encoding: "utf8",
+    },
+  );
+  const tarballName = packOutput.trim().split("\n").at(-1);
+  assert.ok(tarballName, "npm pack did not return a tarball name");
+  writeFileSync(
+    join(temporaryRoot, "package.json"),
+    JSON.stringify({
+      name: "virtua-octane-consumer",
+      private: true,
+      type: "module",
+      allowScripts: { "@tsrx/core": true },
+      dependencies: {
+        octane: "^0.1.36",
+        virtua: `file:${join(temporaryRoot, tarballName)}`,
+      },
+    }),
+  );
+  execFileSync("npm", ["install", "--no-package-lock"], {
+    cwd: temporaryRoot,
+    stdio: "inherit",
+    env: Object.fromEntries(
+      Object.entries(process.env).filter(
+        ([name]) => name.toLowerCase() !== "npm_config_allow_scripts",
+      ),
+    ),
+  });
+
   const entry = join(temporaryRoot, "consumer.tsrx");
   const consumerSource = `import { VList, type VListHandle } from "virtua/octane";
 const items = [{ id: 1, label: "one" }];
@@ -105,7 +141,7 @@ export function Consumer() {
     0,
     ts.formatDiagnosticsWithColorAndContext(diagnostics, {
       getCanonicalFileName: (file) => file,
-      getCurrentDirectory: () => projectRoot,
+      getCurrentDirectory: () => temporaryRoot,
       getNewLine: () => "\n",
     }),
   );

--- a/spec/octane-fixtures.tsrx
+++ b/spec/octane-fixtures.tsrx
@@ -1,0 +1,172 @@
+import type { OctaneElement } from "octane/jsx-runtime";
+import {
+  VList,
+  type VListHandle,
+  type VListProps,
+} from "../src/octane/VList.tsrx";
+import {
+  Virtualizer,
+  type VirtualizerProps,
+} from "../src/octane/Virtualizer.tsrx";
+import {
+  WindowVirtualizer,
+  type WindowVirtualizerHandle,
+} from "../src/octane/WindowVirtualizer.tsrx";
+
+interface Item {
+  id: number;
+  label: string;
+}
+
+interface ListFixtureProps {
+  items: Item[];
+  listRef?: { current: VListHandle | null };
+  keepMounted?: readonly number[];
+  horizontal?: boolean;
+  onScroll?: (offset: number) => void;
+  onScrollEnd?: () => void;
+  ssrCount?: number;
+}
+
+export function ListFixture({
+  items,
+  listRef,
+  keepMounted,
+  horizontal,
+  onScroll,
+  onScrollEnd,
+  ssrCount,
+}: ListFixtureProps): OctaneElement {
+  return (
+    <VList
+      id="octane-list"
+      ref={listRef}
+      data={items}
+      keepMounted={keepMounted}
+      horizontal={horizontal}
+      onScroll={onScroll}
+      onScrollEnd={onScrollEnd}
+      ssrCount={ssrCount}
+      itemSize={50}
+    >
+      {(item: Item, index: number) => (
+        <div key={item.id} data-index={index}>
+          {item.label}
+        </div>
+      )}
+    </VList>
+  );
+}
+
+interface VirtualizerFixtureProps
+  extends Pick<VirtualizerProps<Item>, "as" | "item"> {
+  items: Item[];
+}
+
+export function VirtualizerFixture({
+  items,
+  as,
+  item,
+}: VirtualizerFixtureProps): OctaneElement {
+  return (
+    <div style={{ overflowY: "auto", height: 500 }}>
+      <Virtualizer data={items} as={as} item={item} itemSize={50}>
+        {(entry: Item, index: number) => (
+          <span key={entry.id} data-index={index}>
+            {entry.label}
+          </span>
+        )}
+      </Virtualizer>
+    </div>
+  );
+}
+
+interface WindowFixtureProps {
+  items: Item[];
+  listRef?: { current: WindowVirtualizerHandle | null };
+  ssrCount?: number;
+}
+
+export function WindowFixture({
+  items,
+  listRef,
+  ssrCount,
+}: WindowFixtureProps): OctaneElement {
+  return (
+    <div id="window-list">
+      <WindowVirtualizer
+        ref={listRef}
+        data={items}
+        ssrCount={ssrCount}
+        itemSize={50}
+      >
+        {(item: Item, index: number) => (
+          <div key={item.id} data-index={index}>
+            {item.label}
+          </div>
+        )}
+      </WindowVirtualizer>
+    </div>
+  );
+}
+
+export function AttributeFixture(props: VListProps): OctaneElement {
+  return <VList {...props} />;
+}
+
+interface BrowserListFixtureProps {
+  items: Item[];
+  listRef: { current: VListHandle | null };
+  onScroll: (offset: number) => void;
+}
+
+export function BrowserListFixture({
+  items,
+  listRef,
+  onScroll,
+}: BrowserListFixtureProps): OctaneElement {
+  return (
+    <VList
+      ref={listRef}
+      data={items}
+      onScroll={onScroll}
+      style={{ height: 200, width: 200 }}
+    >
+      {(item: Item, index: number) => (
+        <div key={item.id} data-index={index} style={{ height: 50 }}>
+          {item.label}
+        </div>
+      )}
+    </VList>
+  );
+}
+
+interface TwoListsFixtureProps {
+  first: Item[];
+  second: Item[];
+  firstRef: { current: VListHandle | null };
+  secondRef: { current: VListHandle | null };
+}
+
+export function TwoListsFixture({
+  first,
+  second,
+  firstRef,
+  secondRef,
+}: TwoListsFixtureProps): OctaneElement {
+  return (
+    <main>
+      <VList ref={firstRef} data={first} itemSize={40} style={{ height: 120 }}>
+        {(item: Item) => <div key={item.id}>{item.label}</div>}
+      </VList>
+      <VList
+        ref={secondRef}
+        data={second}
+        itemSize={60}
+        style={{ height: 120 }}
+      >
+        {(item: Item) => <div key={item.id}>{item.label}</div>}
+      </VList>
+    </main>
+  );
+}

--- a/src/octane/ListItem.tsrx
+++ b/src/octane/ListItem.tsrx
@@ -1,0 +1,71 @@
+import {
+  memo,
+  useMemo,
+  useRef,
+  type OctaneNode,
+} from "octane";
+import type { OctaneElement } from "octane/jsx-runtime";
+import type { ItemResizeObserver } from "../core/index.js";
+import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect.js";
+import { refKey } from "./utils.js";
+import type { CSSProperties, CustomItemComponent } from "./types.js";
+
+interface ListItemProps {
+  _children: OctaneNode;
+  _resizer: ItemResizeObserver;
+  _index: number;
+  _offset: number;
+  _hide: boolean;
+  _as: "div" | CustomItemComponent;
+  _isHorizontal: boolean;
+  _isSSR: boolean | undefined;
+}
+
+/**
+ * @internal
+ */
+export const ListItem = /*#__PURE__*/ memo(
+  ({
+    _children: children,
+    _resizer: resizer,
+    _index: index,
+    _offset: offset,
+    _hide: hide,
+    _as: Element,
+    _isHorizontal: isHorizontal,
+    _isSSR: isSSR,
+  }: ListItemProps): OctaneElement => {
+    const ref = useRef<HTMLDivElement | null>(null);
+
+    // The index changes when elements are inserted into or removed from the start.
+    useIsomorphicLayoutEffect(() => resizer(ref[refKey]!, index), [index]);
+
+    const style = useMemo((): CSSProperties => {
+      const style: CSSProperties = {
+        contain: "layout style",
+        position: hide && isSSR ? undefined : "absolute",
+        [isHorizontal ? "height" : "width"]: "100%",
+        [isHorizontal ? "top" : "left"]: 0,
+        [isHorizontal ? "left" : "top"]: offset,
+        visibility: !hide || isSSR ? undefined : "hidden",
+      };
+      if (isHorizontal) {
+        style.display = "inline-flex";
+      }
+      return style;
+    }, [offset, hide, isSSR, isHorizontal]);
+
+    if (typeof Element === "string") {
+      return (
+        <Element ref={ref} style={style}>
+          {children}
+        </Element>
+      );
+    }
+    return (
+      <Element ref={ref} style={style} index={index}>
+        {children}
+      </Element>
+    );
+  },
+);

--- a/src/octane/VList.browser.spec.ts
+++ b/src/octane/VList.browser.spec.ts
@@ -1,0 +1,30 @@
+import { cleanup, fireEvent, render, waitFor } from "@octanejs/testing-library";
+import { afterEach, expect, it, vi } from "vitest";
+import { BrowserListFixture } from "../../spec/octane-fixtures.tsrx";
+import type { VListHandle } from "./VList.tsrx";
+
+afterEach(cleanup);
+
+it("measures and scrolls with the browser ResizeObserver", async () => {
+  const items = Array.from({ length: 100 }, (_, id) => ({
+    id,
+    label: `Item ${id}`,
+  }));
+  const listRef: { current: VListHandle | null } = { current: null };
+  const onScroll = vi.fn();
+  const { container } = render(BrowserListFixture, {
+    props: { items, listRef, onScroll },
+  });
+
+  await waitFor(() => {
+    expect(listRef.current?.viewportSize).toBe(200);
+    expect(listRef.current?.getItemSize(0)).toBe(50);
+  });
+
+  const viewport = container.firstElementChild as HTMLElement;
+  viewport.scrollTop = 150;
+  fireEvent.scroll(viewport);
+
+  await waitFor(() => expect(onScroll).toHaveBeenLastCalledWith(150));
+  expect(listRef.current?.scrollOffset).toBe(150);
+});

--- a/src/octane/VList.spec.ts
+++ b/src/octane/VList.spec.ts
@@ -1,0 +1,161 @@
+import { cleanup, fireEvent, render } from "@octanejs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setupResizeJsDom } from "../../spec/dom.js";
+import {
+  ListFixture,
+  TwoListsFixture,
+  VirtualizerFixture,
+  WindowFixture,
+} from "../../spec/octane-fixtures.tsrx";
+import type { VListHandle } from "./VList.tsrx";
+import type { WindowVirtualizerHandle } from "./WindowVirtualizer.tsrx";
+
+const ITEM_HEIGHT = 50;
+const VIEWPORT_HEIGHT = ITEM_HEIGHT * 10;
+
+setupResizeJsDom({
+  itemSize: { width: 100, height: ITEM_HEIGHT },
+  viewportSize: { width: 100, height: VIEWPORT_HEIGHT },
+});
+
+afterEach(cleanup);
+
+const items = Array.from({ length: 100 }, (_, id) => ({
+  id,
+  label: `Item ${id}`,
+}));
+
+const settleResize = async () => {
+  vi.runAllTicks();
+  await Promise.resolve();
+};
+
+describe("Octane VList", () => {
+  it("renders lazy data and keeps requested offscreen items mounted", async () => {
+    const { container } = render(ListFixture, {
+      props: { items, keepMounted: [20, 90] },
+    });
+    await settleResize();
+
+    expect(container.querySelector('[data-index="0"]')?.textContent).toBe(
+      "Item 0",
+    );
+    expect(container.querySelector('[data-index="20"]')?.textContent).toBe(
+      "Item 20",
+    );
+    expect(container.querySelector('[data-index="90"]')?.textContent).toBe(
+      "Item 90",
+    );
+    expect(container.querySelectorAll("[data-index]").length).toBeLessThan(
+      items.length,
+    );
+  });
+
+  it("exposes the complete imperative handle after dynamic measurement", async () => {
+    const listRef: { current: VListHandle | null } = { current: null };
+    render(ListFixture, { props: { items, listRef } });
+    await settleResize();
+
+    const handle = listRef.current!;
+    expect(handle.getItemSize(0)).toBe(ITEM_HEIGHT);
+    expect(handle.getItemOffset(2)).toBe(ITEM_HEIGHT * 2);
+    expect(handle.findItemIndex(ITEM_HEIGHT * 3)).toBe(3);
+    expect(handle.cache).toBeDefined();
+    expect(handle.scrollOffset).toBe(0);
+    expect(handle.viewportSize).toBe(VIEWPORT_HEIGHT);
+    expect(() => {
+      handle.scrollTo(20);
+      handle.scrollBy(10);
+      handle.scrollToIndex(4);
+    }).not.toThrow();
+  });
+
+  it("forwards native scroll and scroll-end notifications", async () => {
+    const onScroll = vi.fn();
+    const onScrollEnd = vi.fn();
+    const { container } = render(ListFixture, {
+      props: { items, onScroll, onScrollEnd },
+    });
+    await settleResize();
+
+    const viewport = container.firstElementChild as HTMLElement;
+    viewport.scrollTop = 125;
+    fireEvent.scroll(viewport);
+    expect(onScroll).toHaveBeenLastCalledWith(125);
+
+    await new Promise((resolve) => setTimeout(resolve, 160));
+    expect(onScrollEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("updates the existing list when data length changes", async () => {
+    const rendered = render(ListFixture, {
+      props: { items: items.slice(0, 2) },
+    });
+    await settleResize();
+    expect(rendered.container.textContent).toContain("Item 1");
+
+    rendered.rerender(ListFixture, { props: { items: items.slice(0, 3) } });
+    await settleResize();
+    expect(rendered.container.textContent).toContain("Item 2");
+  });
+
+  it("keeps composed hook state isolated across sibling instances and remounts", async () => {
+    const firstRef: { current: VListHandle | null } = { current: null };
+    const secondRef: { current: VListHandle | null } = { current: null };
+    const rendered = render(TwoListsFixture, {
+      props: {
+        first: items.slice(0, 2),
+        second: items.slice(10, 13),
+        firstRef,
+        secondRef,
+      },
+    });
+    const virtualContainers =
+      rendered.container.querySelectorAll("main > div > div");
+    expect((virtualContainers[0] as HTMLElement).style.height).toBe("80px");
+    expect((virtualContainers[1] as HTMLElement).style.height).toBe("180px");
+    await settleResize();
+
+    expect(firstRef.current).not.toBe(secondRef.current);
+    expect(firstRef.current?.getItemSize(0)).toBe(ITEM_HEIGHT);
+    expect(secondRef.current?.getItemSize(0)).toBe(ITEM_HEIGHT);
+    expect(rendered.container.textContent).toContain("Item 0");
+    expect(rendered.container.textContent).toContain("Item 10");
+
+    rendered.unmount();
+    expect(firstRef.current).toBeNull();
+    expect(secondRef.current).toBeNull();
+
+    const remountedRef: { current: VListHandle | null } = { current: null };
+    const remounted = render(ListFixture, {
+      props: { items: items.slice(20, 22), listRef: remountedRef },
+    });
+    await settleResize();
+    expect(remounted.container.textContent).toContain("Item 20");
+    expect(remountedRef.current).not.toBeNull();
+  });
+});
+
+describe("Octane advanced virtualizers", () => {
+  it("supports custom container and item elements", async () => {
+    const { container } = render(VirtualizerFixture, {
+      props: { items: items.slice(0, 5), as: "ul", item: "li" },
+    });
+    await settleResize();
+
+    expect(container.querySelector("ul")).not.toBeNull();
+    expect(container.querySelectorAll("li")).toHaveLength(5);
+  });
+
+  it("provides a measured WindowVirtualizer handle", async () => {
+    const listRef: { current: WindowVirtualizerHandle | null } = {
+      current: null,
+    };
+    render(WindowFixture, { props: { items, listRef } });
+    await settleResize();
+
+    expect(listRef.current?.getItemSize(0)).toBe(ITEM_HEIGHT);
+    expect(listRef.current?.getItemOffset(2)).toBe(ITEM_HEIGHT * 2);
+    expect(listRef.current?.cache).toBeDefined();
+  });
+});

--- a/src/octane/VList.ssr.spec.ts
+++ b/src/octane/VList.ssr.spec.ts
@@ -1,0 +1,29 @@
+/** @vitest-environment node */
+import { renderToStaticMarkup, renderToString } from "octane/server";
+import { describe, expect, it } from "vitest";
+import { ListFixture, WindowFixture } from "../../spec/octane-fixtures.tsrx";
+
+const items = Array.from({ length: 100 }, (_, id) => ({
+  id,
+  label: `Item ${id}`,
+}));
+
+describe("Octane SSR", () => {
+  it.each([renderToString, renderToStaticMarkup])(
+    "renders the requested VList item count",
+    (render) => {
+      const { html } = render(ListFixture, { items, ssrCount: 10 });
+      expect(html.match(/data-index=/g) ?? []).toHaveLength(10);
+      expect(html).toContain('id="octane-list"');
+    },
+  );
+
+  it.each([renderToString, renderToStaticMarkup])(
+    "renders the requested WindowVirtualizer item count",
+    (render) => {
+      const { html } = render(WindowFixture, { items, ssrCount: 8 });
+      expect(html.match(/data-index=/g) ?? []).toHaveLength(8);
+      expect(html).toContain('id="window-list"');
+    },
+  );
+});

--- a/src/octane/VList.tsrx
+++ b/src/octane/VList.tsrx
@@ -1,0 +1,82 @@
+import type { OctaneElement } from "octane/jsx-runtime";
+import type { ViewportComponentAttributes } from "./types.js";
+import {
+  Virtualizer,
+  type VirtualizerHandle,
+  type VirtualizerProps,
+} from "./Virtualizer.tsrx";
+
+/** Methods of {@link VList}. */
+export interface VListHandle extends VirtualizerHandle {}
+
+/** Props of {@link VList}. */
+export interface VListProps<T = unknown>
+  extends
+    Pick<
+      VirtualizerProps<T>,
+      | "children"
+      | "data"
+      | "bufferSize"
+      | "itemSize"
+      | "shift"
+      | "horizontal"
+      | "cache"
+      | "ssrCount"
+      | "item"
+      | "onScroll"
+      | "onScrollEnd"
+      | "keepMounted"
+    >,
+    ViewportComponentAttributes {
+  ref?: { current: VListHandle | null } | ((value: VListHandle | null) => void);
+}
+
+/** Virtualized list component. See {@link VListProps} and {@link VListHandle}. */
+export function VList<T>({
+  children,
+  data,
+  bufferSize,
+  itemSize,
+  shift,
+  horizontal,
+  keepMounted,
+  cache,
+  ssrCount,
+  item,
+  onScroll,
+  onScrollEnd,
+  style,
+  ref,
+  ...attrs
+}: VListProps<T>): OctaneElement {
+  return (
+    <div
+      {...attrs}
+      style={{
+        display: horizontal ? "inline-block" : "block",
+        [horizontal ? "overflowX" : "overflowY"]: "auto",
+        contain: "strict",
+        width: "100%",
+        height: "100%",
+        ...style,
+      }}
+    >
+      <Virtualizer
+        ref={ref}
+        data={data}
+        bufferSize={bufferSize}
+        itemSize={itemSize}
+        shift={shift}
+        horizontal={horizontal}
+        keepMounted={keepMounted}
+        cache={cache}
+        ssrCount={ssrCount}
+        item={item}
+        onScroll={onScroll}
+        onScrollEnd={onScrollEnd}
+      >
+        {children}
+      </Virtualizer>
+    </div>
+  );
+}

--- a/src/octane/Virtualizer.tsrx
+++ b/src/octane/Virtualizer.tsrx
@@ -1,0 +1,252 @@
+import {
+  flushSync,
+  useImperativeHandle,
+  useReducer,
+  useRef,
+  type OctaneNode,
+} from "octane";
+import type { Octane, OctaneElement } from "octane/jsx-runtime";
+import {
+  UPDATE_SCROLL_EVENT,
+  ACTION_ITEMS_LENGTH_CHANGE,
+  createVirtualStore,
+  UPDATE_VIRTUAL_STATE,
+  UPDATE_SCROLL_END_EVENT,
+  getScrollSize,
+  ACTION_START_OFFSET_CHANGE,
+  createScroller,
+  createResizer,
+  type CacheSnapshot,
+  type ScrollToIndexOpts,
+  microtask,
+  sort,
+} from "../core/index.js";
+import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect.js";
+import { getKey, refKey } from "./utils.js";
+import { useStatic } from "./useStatic.js";
+import { useLatestRef } from "./useLatestRef.js";
+import { ListItem } from "./ListItem.tsrx";
+import { useChildren } from "./useChildren.js";
+import type {
+  CustomContainerComponent,
+  CustomItemComponent,
+} from "./types.js";
+
+/** Methods of {@link Virtualizer}. */
+export interface VirtualizerHandle {
+  readonly cache: CacheSnapshot;
+  readonly scrollOffset: number;
+  readonly scrollSize: number;
+  readonly viewportSize: number;
+  findItemIndex(offset: number): number;
+  getItemOffset(index: number): number;
+  getItemSize(index: number): number;
+  scrollToIndex(index: number, opts?: ScrollToIndexOpts): void;
+  scrollTo(offset: number): void;
+  scrollBy(offset: number): void;
+}
+
+/** Props of {@link Virtualizer}. */
+export interface VirtualizerProps<T = unknown> {
+  children: OctaneNode | ((data: T, index: number) => OctaneElement);
+  data?: ArrayLike<T>;
+  bufferSize?: number;
+  itemSize?: number;
+  shift?: boolean;
+  horizontal?: boolean;
+  keepMounted?: readonly number[];
+  cache?: CacheSnapshot;
+  startMargin?: number;
+  ssrCount?: number;
+  as?: keyof Octane.JSX.IntrinsicElements | CustomContainerComponent;
+  item?: keyof Octane.JSX.IntrinsicElements | CustomItemComponent;
+  scrollRef?: { current: HTMLElement | null };
+  onScroll?: (offset: number) => void;
+  onScrollEnd?: () => void;
+  ref?:
+    | { current: VirtualizerHandle | null }
+    | ((value: VirtualizerHandle | null) => void);
+}
+
+/**
+ * Customizable list virtualizer for advanced usage. See {@link VirtualizerProps} and {@link VirtualizerHandle}.
+ */
+export function Virtualizer<T>({
+  children,
+  data,
+  bufferSize,
+  itemSize,
+  shift,
+  horizontal: horizontalProp,
+  keepMounted,
+  cache,
+  startMargin = 0,
+  ssrCount,
+  as: Element = "div",
+  item: ItemElement = "div",
+  scrollRef,
+  onScroll: onScrollProp,
+  onScrollEnd: onScrollEndProp,
+  ref,
+}: VirtualizerProps<T>): OctaneElement {
+  Element = Element as "div";
+
+  const [renderElement, count] = useChildren(children, data);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const isSSR = useRef(!!ssrCount);
+  const onScroll = useLatestRef(onScrollProp);
+  const onScrollEnd = useLatestRef(onScrollEndProp);
+
+  const [store, resizer, scroller, isHorizontal] = useStatic(() => {
+    const horizontal = !!horizontalProp;
+    const virtualStore = createVirtualStore(
+      count,
+      itemSize,
+      ssrCount,
+      cache,
+      !itemSize,
+    );
+    return [
+      virtualStore,
+      createResizer(virtualStore, horizontal),
+      createScroller(virtualStore, horizontal),
+      horizontal,
+    ] as const;
+  });
+
+  // The element and cache lengths briefly differ when items are inserted or removed.
+  if (count !== store.$getItemsLength()) {
+    store.$update(ACTION_ITEMS_LENGTH_CHANGE, [count, shift]);
+  }
+  if (startMargin !== store.$getStartSpacerSize()) {
+    store.$update(ACTION_START_OFFSET_CHANGE, startMargin);
+  }
+
+  const [stateVersion, rerender] = useReducer(
+    store.$getStateVersion,
+    undefined,
+    store.$getStateVersion,
+  );
+  const isScrolling = store.$isScrolling();
+  const totalSize = store.$getTotalSize();
+  const isNegative = scroller.$isNegative();
+  const items: OctaneElement[] = [];
+
+  const renderItem = (index: number) => {
+    const element = renderElement(index);
+    return (
+      <ListItem
+        key={getKey(element, index)}
+        _resizer={resizer.$observeItem}
+        _index={index}
+        _offset={store.$getItemOffset(index, isNegative)}
+        _hide={store.$isUnmeasuredItem(index)}
+        _as={ItemElement as "div"}
+        _children={element}
+        _isHorizontal={isHorizontal}
+        _isSSR={isSSR[refKey]}
+      />
+    );
+  };
+
+  useIsomorphicLayoutEffect(() => {
+    isSSR[refKey] = false;
+
+    // Reason: the store must observe first because resizer/scroller setup may dispatch.
+    store.$subscribe(UPDATE_VIRTUAL_STATE, (sync) => {
+      if (sync) {
+        flushSync(() => rerender(undefined));
+      } else {
+        rerender(undefined);
+      }
+    });
+    store.$subscribe(UPDATE_SCROLL_EVENT, () => {
+      onScroll[refKey]?.(store.$getScrollOffset());
+    });
+    store.$subscribe(UPDATE_SCROLL_END_EVENT, () => {
+      onScrollEnd[refKey]?.();
+    });
+
+    const container = containerRef[refKey]!;
+    const assignScrollableElement = (element: HTMLElement) => {
+      resizer.$observeRoot(element);
+      scroller.$observe(container, element);
+    };
+    if (scrollRef) {
+      // The parent's ref does not exist yet when this layout effect begins.
+      microtask(() => {
+        if (scrollRef[refKey]) {
+          assignScrollableElement(scrollRef[refKey]);
+        }
+      });
+    } else {
+      assignScrollableElement(container.parentElement!);
+    }
+
+    return () => {
+      store.$dispose();
+      resizer.$dispose();
+      scroller.$dispose();
+    };
+  }, []);
+
+  useIsomorphicLayoutEffect(() => {
+    scroller.$fixScrollJump();
+  }, [stateVersion]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      get cache() {
+        return store.$getCacheSnapshot();
+      },
+      get scrollOffset() {
+        return store.$getScrollOffset();
+      },
+      get scrollSize() {
+        return getScrollSize(store);
+      },
+      get viewportSize() {
+        return store.$getViewportSize();
+      },
+      findItemIndex: store.$findItemIndex,
+      getItemOffset: store.$getItemOffset,
+      getItemSize: store.$getItemSize,
+      scrollToIndex: scroller.$scrollToIndex,
+      scrollTo: scroller.$scrollTo,
+      scrollBy: scroller.$scrollBy,
+    }),
+    [],
+  );
+
+  if (keepMounted) {
+    const mounted = new Set(keepMounted);
+    for (let [start, end] = store.$getRange(bufferSize); start <= end; start++) {
+      mounted.add(start);
+    }
+    for (const index of sort([...mounted])) {
+      items.push(renderItem(index));
+    }
+  } else {
+    for (let [start, end] = store.$getRange(bufferSize); start <= end; start++) {
+      items.push(renderItem(start));
+    }
+  }
+
+  return (
+    <Element
+      ref={containerRef}
+      style={{
+        contain: "size style",
+        overflowAnchor: "none",
+        flex: "none",
+        position: "relative",
+        width: isHorizontal ? totalSize : "100%",
+        height: isHorizontal ? "100%" : totalSize,
+        pointerEvents: isScrolling ? "none" : undefined,
+      }}
+    >
+      {items}
+    </Element>
+  );
+}

--- a/src/octane/WindowVirtualizer.tsrx
+++ b/src/octane/WindowVirtualizer.tsrx
@@ -1,0 +1,203 @@
+import {
+  flushSync,
+  useImperativeHandle,
+  useReducer,
+  useRef,
+  type OctaneNode,
+} from "octane";
+import type { Octane, OctaneElement } from "octane/jsx-runtime";
+import {
+  ACTION_ITEMS_LENGTH_CHANGE,
+  UPDATE_VIRTUAL_STATE,
+  createVirtualStore,
+  UPDATE_SCROLL_END_EVENT,
+  UPDATE_SCROLL_EVENT,
+  createWindowScroller,
+  createWindowResizer,
+  type CacheSnapshot,
+  type ScrollToIndexOpts,
+} from "../core/index.js";
+import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect.js";
+import { getKey, refKey } from "./utils.js";
+import { useStatic } from "./useStatic.js";
+import { useLatestRef } from "./useLatestRef.js";
+import type {
+  CustomContainerComponent,
+  CustomItemComponent,
+} from "./types.js";
+import { ListItem } from "./ListItem.tsrx";
+import { useChildren } from "./useChildren.js";
+
+/** Methods of {@link WindowVirtualizer}. */
+export interface WindowVirtualizerHandle {
+  readonly cache: CacheSnapshot;
+  readonly scrollOffset: number;
+  readonly viewportSize: number;
+  findItemIndex(offset: number): number;
+  getItemOffset(index: number): number;
+  getItemSize(index: number): number;
+  scrollToIndex(index: number, opts?: ScrollToIndexOpts): void;
+}
+
+/** Props of {@link WindowVirtualizer}. */
+export interface WindowVirtualizerProps<T = unknown> {
+  children: OctaneNode | ((data: T, index: number) => OctaneElement);
+  data?: ArrayLike<T>;
+  bufferSize?: number;
+  itemSize?: number;
+  shift?: boolean;
+  horizontal?: boolean;
+  cache?: CacheSnapshot;
+  ssrCount?: number;
+  as?: keyof Octane.JSX.IntrinsicElements | CustomContainerComponent;
+  item?: keyof Octane.JSX.IntrinsicElements | CustomItemComponent;
+  onScroll?: () => void;
+  onScrollEnd?: () => void;
+  ref?:
+    | { current: WindowVirtualizerHandle | null }
+    | ((value: WindowVirtualizerHandle | null) => void);
+}
+
+/**
+ * {@link Virtualizer} controlled by window scrolling. See {@link WindowVirtualizerProps} and {@link WindowVirtualizerHandle}.
+ */
+export function WindowVirtualizer<T>({
+  children,
+  data,
+  bufferSize,
+  itemSize,
+  shift,
+  horizontal: horizontalProp,
+  cache,
+  ssrCount,
+  as: Element = "div",
+  item: ItemElement = "div",
+  onScroll: onScrollProp,
+  onScrollEnd: onScrollEndProp,
+  ref,
+}: WindowVirtualizerProps<T>): OctaneElement {
+  Element = Element as "div";
+
+  const [renderElement, count] = useChildren(children, data);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const onScroll = useLatestRef(onScrollProp);
+  const onScrollEnd = useLatestRef(onScrollEndProp);
+  const isSSR = useRef(!!ssrCount);
+
+  const [store, resizer, scroller, isHorizontal] = useStatic(() => {
+    const horizontal = !!horizontalProp;
+    const virtualStore = createVirtualStore(
+      count,
+      itemSize,
+      ssrCount,
+      cache,
+      !itemSize,
+    );
+    return [
+      virtualStore,
+      createWindowResizer(virtualStore, horizontal),
+      createWindowScroller(virtualStore, horizontal),
+      horizontal,
+    ] as const;
+  });
+
+  if (count !== store.$getItemsLength()) {
+    store.$update(ACTION_ITEMS_LENGTH_CHANGE, [count, shift]);
+  }
+
+  const [stateVersion, rerender] = useReducer(
+    store.$getStateVersion,
+    undefined,
+    store.$getStateVersion,
+  );
+  const isScrolling = store.$isScrolling();
+  const totalSize = store.$getTotalSize();
+  const isNegative = scroller.$isNegative();
+  const items: OctaneElement[] = [];
+
+  useIsomorphicLayoutEffect(() => {
+    isSSR[refKey] = false;
+
+    // Reason: the store must observe first because resizer/scroller setup may dispatch.
+    store.$subscribe(UPDATE_VIRTUAL_STATE, (sync) => {
+      if (sync) {
+        flushSync(() => rerender(undefined));
+      } else {
+        rerender(undefined);
+      }
+    });
+    store.$subscribe(UPDATE_SCROLL_EVENT, () => {
+      onScroll[refKey]?.();
+    });
+    store.$subscribe(UPDATE_SCROLL_END_EVENT, () => {
+      onScrollEnd[refKey]?.();
+    });
+
+    const element = containerRef[refKey]!;
+    resizer.$observeRoot(element);
+    scroller.$observe(element);
+    return () => {
+      store.$dispose();
+      resizer.$dispose();
+      scroller.$dispose();
+    };
+  }, []);
+
+  useIsomorphicLayoutEffect(() => {
+    scroller.$fixScrollJump();
+  }, [stateVersion]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      get cache() {
+        return store.$getCacheSnapshot();
+      },
+      get scrollOffset() {
+        return store.$getScrollOffset();
+      },
+      get viewportSize() {
+        return store.$getViewportSize();
+      },
+      findItemIndex: store.$findItemIndex,
+      getItemOffset: store.$getItemOffset,
+      getItemSize: store.$getItemSize,
+      scrollToIndex: scroller.$scrollToIndex,
+    }),
+    [],
+  );
+
+  for (let [start, end] = store.$getRange(bufferSize); start <= end; start++) {
+    const element = renderElement(start);
+    items.push(
+      <ListItem
+        key={getKey(element, start)}
+        _resizer={resizer.$observeItem}
+        _index={start}
+        _offset={store.$getItemOffset(start, isNegative)}
+        _hide={store.$isUnmeasuredItem(start)}
+        _as={ItemElement as "div"}
+        _children={element}
+        _isHorizontal={isHorizontal}
+        _isSSR={isSSR[refKey]}
+      />,
+    );
+  }
+
+  return (
+    <Element
+      ref={containerRef}
+      style={{
+        contain: "size style",
+        overflowAnchor: "none",
+        flex: "none",
+        position: "relative",
+        width: isHorizontal ? totalSize : "100%",
+        height: isHorizontal ? "100%" : totalSize,
+        pointerEvents: isScrolling ? "none" : undefined,
+      }}
+    >
+      {items}
+    </Element>
+  );
+}

--- a/src/octane/index.ts
+++ b/src/octane/index.ts
@@ -1,0 +1,10 @@
+export { VList } from "./VList.tsrx";
+export type { VListProps, VListHandle } from "./VList.tsrx";
+export { Virtualizer } from "./Virtualizer.tsrx";
+export type { VirtualizerProps, VirtualizerHandle } from "./Virtualizer.tsrx";
+export { WindowVirtualizer } from "./WindowVirtualizer.tsrx";
+export type {
+  WindowVirtualizerProps,
+  WindowVirtualizerHandle,
+} from "./WindowVirtualizer.tsrx";
+export type * from "./types.js";

--- a/src/octane/tsconfig.json
+++ b/src/octane/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.json",
+  "tsrx": {
+    "compiler": "octane/compiler"
+  },
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "jsxImportSource": "octane",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "types": ["node"],
+    "plugins": [
+      {
+        "name": "@tsrx/typescript-plugin"
+      }
+    ]
+  },
+  "include": ["./**/*", "../../spec/octane-fixtures.tsrx"],
+  "exclude": ["../../node_modules"]
+}

--- a/src/octane/types.ts
+++ b/src/octane/types.ts
@@ -1,0 +1,45 @@
+import type { OctaneNode } from "octane";
+import type { Octane, OctaneElement } from "octane/jsx-runtime";
+
+type HTMLElementAttributes = Octane.HTMLAttributes<HTMLElement>;
+type AriaAttributeName = Extract<keyof HTMLElementAttributes, `aria-${string}`>;
+
+export type ViewportComponentAttributes = Pick<
+  HTMLElementAttributes,
+  | "className"
+  | "id"
+  | "role"
+  | "tabIndex"
+  | "onKeyDown"
+  | "onWheel"
+  | AriaAttributeName
+> & { style?: CSSProperties };
+
+export type CSSProperties = Exclude<
+  Octane.JSX.IntrinsicElements["div"]["style"],
+  string | undefined
+>;
+
+export interface CustomContainerComponentProps {
+  style: CSSProperties;
+  children: OctaneNode;
+  ref?: Octane.Ref<any>;
+}
+
+export type CustomContainerComponent = (
+  props: CustomContainerComponentProps,
+) => OctaneElement;
+
+/**
+ * Props of customized item component for {@link Virtualizer} or {@link WindowVirtualizer}.
+ */
+export interface CustomItemComponentProps {
+  style: CSSProperties;
+  index: number;
+  children: OctaneNode;
+  ref?: Octane.Ref<any>;
+}
+
+export type CustomItemComponent = (
+  props: CustomItemComponentProps,
+) => OctaneElement;

--- a/src/octane/useChildren.ts
+++ b/src/octane/useChildren.ts
@@ -1,0 +1,19 @@
+import { useMemo, type OctaneNode } from "octane";
+import type { OctaneElement } from "octane/jsx-runtime";
+import { type ItemElement, flattenChildren } from "./utils.js";
+
+/**
+ * @internal
+ */
+export const useChildren = <T>(
+  children: OctaneNode | ((data: T, index: number) => OctaneElement),
+  data: ArrayLike<T> | undefined,
+) => {
+  return useMemo((): [(index: number) => ItemElement, number] => {
+    if (typeof children === "function") {
+      return [(index) => children(data![index]!, index), data!.length];
+    }
+    const elements = flattenChildren(children);
+    return [(index) => elements[index]!, elements.length];
+  }, [children, data]);
+};

--- a/src/octane/useIsomorphicLayoutEffect.ts
+++ b/src/octane/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,9 @@
+import { useEffect, useLayoutEffect } from "octane";
+import { isBrowser } from "../core/index.js";
+
+/**
+ * @internal
+ */
+export const useIsomorphicLayoutEffect = isBrowser
+  ? useLayoutEffect
+  : useEffect;

--- a/src/octane/useLatestRef.ts
+++ b/src/octane/useLatestRef.ts
@@ -1,0 +1,16 @@
+import { useRef } from "octane";
+import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect.js";
+import { refKey } from "./utils.js";
+
+/**
+ * @internal
+ */
+export const useLatestRef = <T>(value: T) => {
+  const ref = useRef<T>(value);
+
+  useIsomorphicLayoutEffect(() => {
+    ref[refKey] = value;
+  }, [value]);
+
+  return ref;
+};

--- a/src/octane/useStatic.ts
+++ b/src/octane/useStatic.ts
@@ -1,0 +1,10 @@
+import { useRef } from "octane";
+import { refKey } from "./utils.js";
+
+/**
+ * @internal
+ */
+export const useStatic = <T>(init: () => T): T => {
+  const ref = useRef<T | null>(null);
+  return ref[refKey] || (ref[refKey] = init());
+};

--- a/src/octane/utils.ts
+++ b/src/octane/utils.ts
@@ -1,0 +1,45 @@
+import type { OctaneNode } from "octane";
+import type { Octane } from "octane/jsx-runtime";
+
+/**
+ * @internal
+ */
+export const refKey = "current";
+
+/**
+ * @internal
+ */
+export type ItemElement = Exclude<OctaneNode, null | boolean | Array<unknown>>;
+
+const forEach = (children: OctaneNode, elements: ItemElement[]) => {
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      forEach(child, elements);
+    }
+  } else if (children == null || typeof children === "boolean") {
+    // Filter nullish and boolean children, matching the React adapter.
+  } else {
+    elements.push(children);
+  }
+};
+
+/**
+ * Flatten children without cloning element descriptors.
+ *
+ * @internal
+ */
+export const flattenChildren = (children: OctaneNode): ItemElement[] => {
+  const elements: ItemElement[] = [];
+  forEach(children, elements);
+  return elements;
+};
+
+type MayHaveKey = { key?: Octane.Key };
+
+/**
+ * @internal
+ */
+export const getKey = (element: ItemElement, index: number): Octane.Key => {
+  const key = (element as MayHaveKey).key;
+  return key != null ? key : "_" + index;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,6 @@
     "allowUnusedLabels": false,
     "stripInternal": true
   },
-  "include": ["src"],
-  "exclude": ["node_modules"]
+  "include": ["src", "scripts"],
+  "exclude": ["node_modules", "src/octane"]
 }

--- a/vite.build.config.ts
+++ b/vite.build.config.ts
@@ -6,6 +6,7 @@ import dts from "vite-plugin-dts";
 import solid from "vite-plugin-solid";
 import vueJsx from "unplugin-vue-jsx/vite";
 import angular from "@analogjs/vite-plugin-angular";
+import { octane } from "octane/compiler/vite";
 import pkg from "./package.json" with { type: "json" };
 import annotateVueVNode from "./scripts/babel-plugin-annotate-vue-vnode.js";
 
@@ -102,7 +103,7 @@ export default defineConfig(({ mode }): UserConfig => {
             tsconfigPath: "./tsconfig.json",
             include: ["src"],
             // angular d.ts are emitted by ngc with tsconfig.angular.build.json
-            exclude: ["**/*.{spec,stories}.*", "src/angular"],
+            exclude: ["**/*.{spec,stories}.*", "src/angular", "src/octane"],
             beforeWriteFile: (filePath, content) =>
               filePath.endsWith(`core${path.sep}index.d.ts`)
                 ? { content: "// @ts-nocheck\n" + content }
@@ -239,6 +240,38 @@ export default defineConfig(({ mode }): UserConfig => {
           }),
         ],
       };
+    case "octane":
+    case "octane-ssr": {
+      const server = mode === "octane-ssr";
+      return {
+        plugins: [octane({ ssr: server })],
+        resolve: {
+          alias: server
+            ? [{ find: /^octane$/, replacement: "octane/server" }]
+            : [],
+          extensions: [".tsrx", ".ts", ".mjs", ".js", ".json"],
+        },
+        build: {
+          ...shared,
+          outDir: server ? "lib/octane/server" : "lib/octane/client",
+          lib: {
+            entry: "src/octane/index.ts",
+            formats: ["es"],
+            fileName: () => "index.js",
+          },
+          rolldownOptions: {
+            external,
+            output: {
+              banner:
+                "// octane-no-slot: compiler-assigned hook slots are already present.",
+              ...(server && { paths: { octane: "octane/server" } }),
+            },
+          },
+          minify: "terser",
+          terserOptions: terserOptions(),
+        },
+      };
+    }
     default:
       throw new Error(`unknown build mode: ${mode}`);
   }

--- a/vite.build.config.ts
+++ b/vite.build.config.ts
@@ -262,8 +262,10 @@ export default defineConfig(({ mode }): UserConfig => {
           rolldownOptions: {
             external,
             output: {
-              banner:
-                "// octane-no-slot: compiler-assigned hook slots are already present.",
+              // postBanner is applied after minification so terser does not
+              // strip the marker line comment the octane compiler looks for
+              postBanner:
+                "// octane-no-slot: compiler-assigned hook slots are already present.\n",
               ...(server && { paths: { octane: "octane/server" } }),
             },
           },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ import { svelte } from "@sveltejs/vite-plugin-svelte";
 import angular from "@analogjs/vite-plugin-angular";
 import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
 import { playwright } from "@vitest/browser-playwright";
+import { octane } from "octane/compiler/vite";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -72,6 +73,67 @@ export default defineConfig({
           // Resolve svelte's client (browser) build so `mount` works in jsdom.
           // The SSR spec runs in the node environment and is unaffected.
           conditions: ["browser"],
+        },
+      },
+      {
+        plugins: [octane()],
+        resolve: {
+          extensions: [".tsrx", ".ts", ".mjs", ".js", ".json"],
+        },
+        test: {
+          name: "octane",
+          dir: "src/octane",
+          include: ["**/*.spec.ts"],
+          exclude: ["**/*.ssr.spec.ts", "**/*.browser.spec.ts"],
+          environment: "jsdom",
+          setupFiles: ["./spec/setup.ts"],
+        },
+      },
+      {
+        plugins: [octane({ ssr: true })],
+        resolve: {
+          alias: [
+            {
+              find: /^octane$/,
+              replacement: path.join(
+                dirname,
+                "node_modules/octane/dist/server/index.js",
+              ),
+            },
+          ],
+          extensions: [".tsrx", ".ts", ".mjs", ".js", ".json"],
+        },
+        test: {
+          name: "octane-ssr",
+          dir: "src/octane",
+          include: ["**/*.ssr.spec.ts"],
+          environment: "node",
+        },
+      },
+      {
+        plugins: [octane()],
+        resolve: {
+          extensions: [".tsrx", ".ts", ".mjs", ".js", ".json"],
+        },
+        optimizeDeps: {
+          include: ["@testing-library/dom"],
+        },
+        test: {
+          name: "octane-browser",
+          include: ["src/octane/**/*.browser.spec.ts"],
+          onUnhandledError(error) {
+            // Chromium defers a ResizeObserver delivery while measured list styles converge.
+            return !String(error).includes(
+              "ResizeObserver loop completed with undelivered notifications",
+            );
+          },
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright(),
+            instances: [{ browser: "chromium" }],
+            screenshotFailures: false,
+          },
         },
       },
       {


### PR DESCRIPTION
## Summary

- add a native `virtua/octane` entry for `VList`, `Virtualizer`, and `WindowVirtualizer`
- reuse the existing core while mirroring the mature adapter behavior: imperative handles, lazy data, dynamic measurement, scrolling, `scrollEnd`, keep-mounted items, and custom containers/items
- ship browser and Node/SSR conditional exports plus Octane-native declarations
- preserve compiler hook-slot markers in minified packages
- add unit, Chromium, SSR, type, package, and bundle-size verification

## Scope

The experimental `VGrid` is intentionally not included in this first adapter.

## Validation

- `npm run tsc`
- `npm run lint -- --no-cache` (0 errors; existing warnings only)
- `npm test` (27 files, 332 tests)
- `npm run build`
- `npm run size`
- `npm run format:ci`
- real `npm pack` installation with isolated type and browser build checks

## Dependency

Independent of the reactivity-store and git-diff-view Octane work; this PR can be reviewed and merged on its own.